### PR TITLE
Fix style when hovering over checked ToggleSwitch

### DIFF
--- a/src/components/ToggleSwitch/theme.ts
+++ b/src/components/ToggleSwitch/theme.ts
@@ -73,11 +73,14 @@ export const theme: Function = ({size, skin}: { size: Size, skin: Skin }) => ({
     backgroundColorChecked: skins.skinToBackgroundColorChecked[skin],
     backgroundColorDisabled: palette.disabledButton,
     backgroundColorHover: skins.skinToHoverBackgroundColor[skin],
+    backgroundColorHoverChecked: skins.skinToHoverBackgroundColor[skin],
     backgroundColorFocus: skins.skinToHoverBackgroundColor[skin],
 
     color: skins.skinToColor[skin],
     colorChecked: skins.skinToColorChecked[skin],
     colorDisabled: palette.disabledDividers,
     colorCheckedDisabled: palette.disabledButton,
-    colorHover: skins.skinToHoverColor[skin]
+    colorHover: skins.skinToHoverColor[skin],
+    colorHoverChecked: skins.skinToHoverColor[skin],
+    colorFocus: skins.skinToHoverColor[skin]
 });


### PR DESCRIPTION
Before (on hover):
<img width="50" alt="screen shot 2018-01-14 at 21 56 20" src="https://user-images.githubusercontent.com/3264697/34920091-cadda522-f975-11e7-9576-220bca09e802.png">

After (on hover):
<img width="47" alt="screen shot 2018-01-14 at 21 54 19" src="https://user-images.githubusercontent.com/3264697/34920079-97de72fa-f975-11e7-88c2-b7eb29c9d4c4.png">