### PR TITLE
Checkbox: use icons from wix-ui-icons-common

### DIFF
--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -3,40 +3,8 @@
   -st-named: Checkbox, CheckboxStyle;
 }
 
-:import {
-  -st-from: "../../palette.st.css";
-  -st-named: mainMuted, main, mainHover, disabled, successMutedHover, dangerMutedHover, success, danger, successHover, dangerHover, dividerColor, disabled;
-}
-
 .root {
   -st-extends: Checkbox;
   -st-states: error, success, x-small, small;
-  -st-mixin: CheckboxStyle(
-    rootWidth initial,
-    rootHeight initial,
-
-    outerLabelWidth 45px,
-    outerLabelHeight 24px,
-
-    innerLabelWidth 21px,
-    innerLabelHeight 22px,
-    innerLabelBackgroundColor white,
-
-    backgroundColor value(mainMuted),
-    backgroundColorChecked value(main),
-    backgroundColorDisabled value(disabled),
-    backgroundColorHover value(mainHover),
-    backgroundColorFocus value(mainHover),
-
-    color value(mainMuted),
-    colorChecked value(main),
-    colorDisabled value(dividerColor),
-    colorCheckedDisabled value(disabled),
-    colorHover value(mainHover),
-    colorFocus value(mainHover),
-
-    toggleIconWidth 8px,
-    toggleIconHeight 6px,
-    toggleIconDisplay block
-  );
+  -st-mixin: CheckboxStyle;
 }

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {Checkbox as CoreCheckbox, CheckboxProps as CoreCheckboxProps} from 'wix-ui-core/Checkbox';
 import style from './Checkbox.st.css';
 import {withStylable} from 'wix-ui-core/withStylable';
+import {CheckboxChecked, CheckboxIndeterminate} from 'wix-ui-icons-common/system';
 
 export interface CheckboxProps {
   skin?: 'standard' | 'error' | 'success';
@@ -10,7 +11,9 @@ export interface CheckboxProps {
 
 const defaultProps = {
   skin: 'standard',
-  size: 'large'
+  size: 'large',
+  checkedIcon: <CheckboxChecked />,
+  indeterminateIcon: <CheckboxIndeterminate />
 };
 
 export const Checkbox = withStylable<CoreCheckboxProps, CheckboxProps>(


### PR DESCRIPTION
For inexplicable reason all mixin parameters were for the toggle switch, removed them.