### PR TITLE
add propper lint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "stylable-integration": "latest",
     "surge-github-autorelease": "^1.0.23",
     "ts-jest": "^22.0.3",
+    "tslint-react": "^3.5.1",
     "typescript": "^2.6.2",
     "wait-for-cond": "^1.5.1",
     "wix-storybook-utils": "latest",

--- a/src/components/CounterBadge/CounterBadge.protractor.driver.ts
+++ b/src/components/CounterBadge/CounterBadge.protractor.driver.ts
@@ -1,6 +1,6 @@
 import {badgeDriverFactory} from 'wix-ui-core/dist/src/components/Badge/Badge.protractor.driver';
 
-export const counterBadgeDriverFactory = (component) => {
+export const counterBadgeDriverFactory = component => {
   return {
     ...badgeDriverFactory(component)
   };

--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -60,7 +60,7 @@ export class ToggleSwitch extends React.PureComponent<ToggleSwitchProps & CoreTo
         {...desiredProps}
         checkedIcon={checkedIconMap[this.props.size]}
         uncheckedIcon={uncheckedIconMap[this.props.size]}
-        />
+      />
     );
   }
 }

--- a/stories/Autocomplete.story.tsx
+++ b/stories/Autocomplete.story.tsx
@@ -15,8 +15,8 @@ export default {
   },
 
   exampleProps: {
-    fixedFooter: [null, <div>Fixed Footer</div>],
-    fixedHeader: [null, <div>Fixed Header</div>],
+    fixedFooter: [null, <div key="1">Fixed Footer</div>],
+    fixedHeader: [null, <div key="2">Fixed Header</div>],
     onSelect: (option: Option) => option.value,
     initialSelectedId: [null, 1],
     onManualInput: (value: string) => `Manual input: ${value}`,

--- a/stories/Badge/index.tsx
+++ b/stories/Badge/index.tsx
@@ -45,7 +45,7 @@ class ControlledBadgeExample extends React.Component<any, any> {
             prefixIcon={this.state.prefixIcon === 'ArrowDown' ? <ChevronDown/> : null}
             suffixIcon={this.state.suffixIcon === 'ArrowDown' ? <ChevronDown/> : null}
             dataHook="storybook-badge"
-            >
+          >
             {this.state.children}
           </Badge>
         </div>

--- a/stories/Heading/index.tsx
+++ b/stories/Heading/index.tsx
@@ -42,7 +42,7 @@ class ControlleHeadingExample extends React.Component<any, any> {
                 dataHook="storybook-heading"
                 ellipsis={this.state.ellipsis}
                 forceHideTitle={this.state.forceHideTitle}
-                >
+              >
                 {this.state.children}
               </Heading>
             </div>

--- a/stories/LabelWithOptions.story.tsx
+++ b/stories/LabelWithOptions.story.tsx
@@ -16,8 +16,8 @@ export default {
   },
 
   exampleProps: {
-    fixedFooter: [null, <div>Fixed Footer</div>],
-    fixedHeader: [null, <div>Fixed Header</div>],
+    fixedFooter: [null, <div key="1">Fixed Footer</div>],
+    fixedHeader: [null, <div key="2">Fixed Header</div>],
     onSelect: (option: Option) => option.value,
     onDeselect: (option: Option) => option.value,
     initialSelectedIds: [null, [1]],

--- a/stories/StylableCounterBadge/index.tsx
+++ b/stories/StylableCounterBadge/index.tsx
@@ -32,7 +32,7 @@ class ControlleCounterdBadgeExample extends React.Component<any, any> {
           <CounterBadge
             skin={this.state.skin}
             dataHook="storybook-counterBadge"
-            >
+          >
             {this.state.children === 'Facebook' ? <Facebook/> : this.state.children}
           </CounterBadge>
         </div>

--- a/stories/Text/index.tsx
+++ b/stories/Text/index.tsx
@@ -55,7 +55,7 @@ class ControlleTextExample extends React.Component<any, any> {
                 ellipsis={this.state.ellipsis}
                 forceHideTitle={this.state.forceHideTitle}
                 dataHook="storybook-text"
-                >
+              >
                 {this.state.children}
               </Text>
             </div>

--- a/stories/ToggleSwitch/index.tsx
+++ b/stories/ToggleSwitch/index.tsx
@@ -42,7 +42,7 @@ class ControlleToggleSwitchExample extends React.Component<any, any> {
             disabled={this.state.disabled}
             onChange={() => this.setState({checked: !this.state.checked})}
             dataHook="storybook-toggleSwitch"
-            />
+          />
         </div>
       </div>
     );

--- a/stories/Tooltip/index.tsx
+++ b/stories/Tooltip/index.tsx
@@ -4,9 +4,15 @@ import {Tooltip} from '../../src/components/Tooltip';
 
 function createTooltip(direction, bounce) {
   return (
-    <Tooltip data-hook={`story-tooltip-${direction}`} placement={direction}
-             minWidth={'100px'} textAlign={'center'} padding={'5px'}
-             content={'I am a message'} bounce={bounce}>
+    <Tooltip
+      data-hook={`story-tooltip-${direction}`}
+      placement={direction}
+      minWidth={'100px'}
+      textAlign={'center'}
+      padding={'5px'}
+      content={'I am a message'}
+      bounce={bounce}
+    >
       <span>I need a tooltip</span>
     </Tooltip>
   );

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,15 @@
 {
   "extends": [
-    "tslint-config-wix"
-  ]
+    "tslint-config-wix",
+    "tslint-react"
+  ],
+  "rules": {
+    "space-in-brackets": ["error", "always"],
+    "array-bracket-spacing": [true, "never"],
+    "comma-dangle": ["error", "never"],
+    "jsx-no-lambda": false,
+    "jsx-no-multiline-js": false,
+    "jsx-boolean-value": false,
+    "arrow-parens": [true, "ban-single-arg-parens"]
+  }
 }


### PR DESCRIPTION
The common wix [tslint-config-wix](https://github.com/wix/tslint-config-wix/blob/master/tslint.json) project, which comes in the stack for ts project uses only the common [tslint-eslint-rules](https://github.com/buzinas/tslint-eslint-rules#eslint-rules-for-tslint), but it doesn't use the [tslint-react](https://github.com/palantir/tslint-react/blob/master/tslint-react.json) which has some nice rules and is considered a best practice: https://github.com/palantir/tslint#tslint.

I added tslint-react, but I have overridden some if its rules

Please let's choose the rules we want to have, and then we can apply it on the wix-ui libs.

We can create one shared tslint file, and not to duplicate it.

The best solution would be to add the `tslint-react` to `tslint-config-wix`, but it will break the world with lints

