### PR TITLE
GlobalHelper - Add HelperContent component

### DIFF
--- a/src/components/GlobalHelper/DataHooks.ts
+++ b/src/components/GlobalHelper/DataHooks.ts
@@ -1,0 +1,3 @@
+export const DataHooks = {
+  innerContent: 'inner-content'
+};

--- a/src/components/GlobalHelper/GlobalHelper.e2e.ts
+++ b/src/components/GlobalHelper/GlobalHelper.e2e.ts
@@ -1,5 +1,5 @@
 import * as eyes from 'eyes.it';
-import {browser} from 'protractor';
+import {browser, ElementFinder} from 'protractor';
 import {getStoryUrl, waitForVisibilityOf} from 'wix-ui-test-utils/protractor';
 
 import {globalHelperTestkitFactory} from '../../testkit/protractor';
@@ -7,6 +7,7 @@ import {storySettings} from './../../../stories/GlobalHelper/StorySettings';
 
 describe('GlobalHelper', () => {
     const storyUrl = getStoryUrl(storySettings.kind, storySettings.story);
+
     const driver = globalHelperTestkitFactory({dataHook: storySettings.dataHook});
 
     beforeEach(async () => {
@@ -14,7 +15,8 @@ describe('GlobalHelper', () => {
         await waitForVisibilityOf(driver.element(), 'Cannot find GlobalHelper');
     });
 
-    eyes.it('should display correct content', async () => {
-        await expect(driver.getContentElement().getText()).toBe('This is the GlobalHelper content');
+    eyes.it('should display title', async () => {
+        expect(await driver.getHelperContentDriver().hasTitle()).toBeTruthy();
+        expect(await driver.getHelperContentDriver().getTitleText()).toBe('This is the title');
     });
 });

--- a/src/components/GlobalHelper/GlobalHelper.protractor.driver.ts
+++ b/src/components/GlobalHelper/GlobalHelper.protractor.driver.ts
@@ -1,3 +1,12 @@
+import {$, ElementFinder, by} from 'protractor';
 import {popoverDriverFactory} from 'wix-ui-core/dist/src/baseComponents/Popover/Popover.protractor.driver';
+import {DataHooks} from './DataHooks';
+import {helperContentDriverFactory} from './content/HelperContent.protractor.driver';
+import {dataHookLocator} from '../../../test/utils/protractor';
 
-export const globalHelperDriverFactory = popoverDriverFactory;
+export const globalHelperDriverFactory = (element: ElementFinder) => {
+  return {
+    ...popoverDriverFactory(element),
+    getHelperContentDriver: () =>  helperContentDriverFactory(element.$(dataHookLocator(DataHooks.innerContent))),
+  };
+};

--- a/src/components/GlobalHelper/GlobalHelper.st.css
+++ b/src/components/GlobalHelper/GlobalHelper.st.css
@@ -15,9 +15,7 @@
 
 .root {
   -st-states: bounce, placement-right, placement-left, placement-top, placement-bottom;
-  /* -st-extends: Tooltip; */
   -st-extends: Popover;
-  white-space: nowrap;
 }
 
 /* popoverContent and innerContent are taken from Tooltip.tooltipContent,

--- a/src/components/GlobalHelper/GlobalHelper.tsx
+++ b/src/components/GlobalHelper/GlobalHelper.tsx
@@ -3,6 +3,7 @@ import {Popover, PopoverProps} from 'wix-ui-core/dist/src/baseComponents/Popover
 import style from './GlobalHelper.st.css';
 import {withStylable} from 'wix-ui-core/withStylable';
 import {createComponentThatRendersItsChildren, ElementProps} from 'wix-ui-core/dist/src/utils';
+import {DataHooks} from './DataHooks';
 
 /**
  * Adapts Popover API with Popover.Element, and Popover.Content into regular props
@@ -24,7 +25,7 @@ export type GlobalHelperType = React.SFC<GlobalHelperProps>;
 const defaultProps = {
 };
 
-const getState: (p?: any, s?: any, c?: any) => StateMap = (p) => ({});
+const getState: (p?: any, s?: any, c?: any) => StateMap = p => ({});
 
 const GlobalHelperBO = withStylable<PopoverProps, GlobalHelperOwnProps>(
   Popover,
@@ -33,7 +34,7 @@ const GlobalHelperBO = withStylable<PopoverProps, GlobalHelperOwnProps>(
   defaultProps
 );
 
-export const GlobalHelper: GlobalHelperType = (props) => {
+export const GlobalHelper: GlobalHelperType = props => {
   const {children, content, ...rest} = props;
   return (
     <GlobalHelperBO {...rest}>
@@ -41,7 +42,7 @@ export const GlobalHelper: GlobalHelperType = (props) => {
           {children}
         </Popover.Element>
         <Popover.Content>
-          <div className={style.innerContent}>
+          <div data-hook={DataHooks.innerContent} className={style.innerContent}>
             {content}
           </div>
         </Popover.Content>

--- a/src/components/GlobalHelper/content/DataHooks.ts
+++ b/src/components/GlobalHelper/content/DataHooks.ts
@@ -1,0 +1,3 @@
+export const DataHooks = {
+  title: 'helper-content-title'
+};

--- a/src/components/GlobalHelper/content/HelperContent.protractor.driver.ts
+++ b/src/components/GlobalHelper/content/HelperContent.protractor.driver.ts
@@ -1,0 +1,12 @@
+import {ElementFinder} from 'protractor';
+import {DataHooks} from './DataHooks';
+import {dataHookLocator} from '../../../../test/utils/protractor';
+import {textDriverFactory} from '../../Text/Text.protractor.driver';
+
+export const helperContentDriverFactory = (element: ElementFinder) => {
+  const title = () => element.$(dataHookLocator(DataHooks.title));
+  return {
+    hasTitle: async () => title().isPresent(),
+    getTitleText: async () => textDriverFactory(title()).getText()
+  };
+};

--- a/src/components/GlobalHelper/content/HelperContent.st.css
+++ b/src/components/GlobalHelper/content/HelperContent.st.css
@@ -9,12 +9,4 @@
 }
 
 .root {
-  /* display: inline-block; */
-  /* font-family: value(fontRoman); */
-  /* text-align: center; */
-  /* color: value(backgroundSecondary); */
-  /* word-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  line-height: 1.29; */
 }

--- a/src/components/GlobalHelper/content/HelperContent.st.css
+++ b/src/components/GlobalHelper/content/HelperContent.st.css
@@ -1,0 +1,20 @@
+:import {
+  -st-from: "../../../palette.st.css";
+  -st-named: brandSecondary, backgroundSecondary
+}
+
+:import {
+  -st-from: "../../../typography.st.css";
+  -st-named: fontRoman;
+}
+
+.root {
+  /* display: inline-block; */
+  /* font-family: value(fontRoman); */
+  /* text-align: center; */
+  /* color: value(backgroundSecondary); */
+  /* word-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-size: 14px;
+  line-height: 1.29; */
+}

--- a/src/components/GlobalHelper/content/HelperContent.tsx
+++ b/src/components/GlobalHelper/content/HelperContent.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import style from './HelperContent.st.css';
+import {Text} from '../../Text';
+import {DataHooks} from './DataHooks';
+
+export interface HelperContentProps {
+  /** Adds text as the title */
+  title: string;
+}
+
+export const HelperContent = (props: HelperContentProps) => {
+  return (
+    <div {...style('root', {}, props)}>
+      {props.title &&
+        <div className={style.title}>
+          <Text dataHook={DataHooks.title} appearance="T2.2" light>
+            {props.title}
+          </Text>
+        </div>
+      }
+    </div>
+  );
+
+};

--- a/src/testkit/protractor.ts
+++ b/src/testkit/protractor.ts
@@ -1,4 +1,5 @@
 import {protractorTestkitFactoryCreator} from 'wix-ui-test-utils/protractor';
+import {ElementFinder} from 'protractor';
 
 import {counterBadgeDriverFactory} from '../components/CounterBadge/CounterBadge.protractor.driver';
 export const counterBadgeTestkitFactory = protractorTestkitFactoryCreator(counterBadgeDriverFactory);

--- a/stories/GlobalHelper/GlobalHelper.story.tsx
+++ b/stories/GlobalHelper/GlobalHelper.story.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import {GlobalHelper} from '../../src/components/GlobalHelper';
+import {HelperContent} from '../../src/components/GlobalHelper/content/HelperContent';
+
 import {storySettings} from './StorySettings';
 
 export default {
@@ -11,7 +13,7 @@ export default {
   componentProps: {
     'data-hook': storySettings.dataHook,
     shown: true,
-    content: <span>This is the GlobalHelper content</span>,
+    content: <HelperContent title="This is the title"/>,
     children: <span>I am a GlobalHelper target</span>,
     placement: 'right'
   },

--- a/test/utils/protractor.ts
+++ b/test/utils/protractor.ts
@@ -1,0 +1,3 @@
+export function dataHookLocator(hook: string) {
+  return `[data-hook='${hook}']`;
+}


### PR DESCRIPTION
This HelperContent is some-what similar to the WSR SectionHelper.
I try to make it a bit better and we might re-use (rename , move ) it for SectionHelper in the future.

- Add a HelperContent component, with Title only (currently).
This component will have also text, button and image.
- Fix some of the PR comment from the global_helper/master PR
