### PR TITLE
`<Button>` - add basic styling props (skin, priority, size)

### DIFF
--- a/src/components/Button/Button.driver.ts
+++ b/src/components/Button/Button.driver.ts
@@ -1,8 +1,8 @@
-import { Skin , Priority, Size} from './constants';
+import { StylableDOMUtil } from 'stylable/test-utils';
 import {buttonDriverFactory as coreButtonDriverFactory} from 'wix-ui-core/dist/src/components/Button/Button.driver';
 import { DriverFactory, BaseDriver } from 'wix-ui-test-utils/driver-factory';
-import { StylableDOMUtil } from 'stylable/test-utils';
 import style from './Button.st.css';
+import { Skin , Priority, Size} from './constants';
 
 export interface ButtonDriver extends BaseDriver {
   getSkin: ()=> Skin;

--- a/src/components/Button/Button.driver.ts
+++ b/src/components/Button/Button.driver.ts
@@ -1,7 +1,22 @@
-import {buttonDriverFactory as ButtonDriverFactory} from 'wix-ui-core/dist/src/components/Button/Button.driver';
+import { Skin , Priority, Size} from './constants';
+import {buttonDriverFactory as coreButtonDriverFactory} from 'wix-ui-core/dist/src/components/Button/Button.driver';
+import { DriverFactory, BaseDriver } from 'wix-ui-test-utils/driver-factory';
+import { StylableDOMUtil } from 'stylable/test-utils';
+import style from './Button.st.css';
 
-export const buttonDriverFactory = ({element, eventTrigger}) => {
+export interface ButtonDriver extends BaseDriver {
+  getSkin: ()=> Skin;
+  getPriority: ()=> Priority;
+  getSize: ()=> Size;
+}
+
+export const buttonDriverFactory : DriverFactory<ButtonDriver>= ({element, eventTrigger}) => {
+  const stylableDOMUtil = new StylableDOMUtil(style, element);
+  const getStyleState = <T>(stateName: string) => stylableDOMUtil.getStyleState(element, stateName) as any as T;
   return {
-    ...ButtonDriverFactory({element, eventTrigger})
+    ...coreButtonDriverFactory({element, eventTrigger}),
+    getSkin: ()=> getStyleState<Skin>('skin'),
+    getPriority: ()=> getStyleState<Priority>('priority'),
+    getSize: ()=> getStyleState<Size>('size'),
   };
 };

--- a/src/components/Button/Button.e2e.ts
+++ b/src/components/Button/Button.e2e.ts
@@ -9,7 +9,7 @@ describe('Button', () => {
 
   beforeEach(() => browser.get(storyUrl));
 
-  eyes.it('should render', async () => {
+  eyes.it('should render with default props', async () => {
     const driver = buttonTestkitFactory({dataHook});
     expect(await driver.element().isPresent()).toBeTruthy();
   });

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -9,51 +9,50 @@ import {Button,ButtonProps} from './';
 import {Skin, Priority, Size} from './constants';
 import {enumValues} from '../../utils';
 
-
 describe('Button', () => {
   const createDriver = createDriverFactory(buttonDriverFactory);
-  const PButton = partialHOC(Button, 
+  const ButtonWithDefaults = withDefaultsHOC(Button, 
     {
       children: 'Click me!'
     });
 
   describe('skin prop', () => {
-    it(`should be '${Skin.standard}' by default`, () => {
-      const driver = createDriver(<PButton/>);
+    it('should be standard by default', () => {
+      const driver = createDriver(<ButtonWithDefaults/>);
       expect(driver.getSkin()).toBe(Skin.standard);
     });
 
     enumValues(Skin).forEach((skin: Skin) => {
       it(`should be '${skin}'`, () => {
-        const driver = createDriver(<PButton skin={skin}/>);
+        const driver = createDriver(<ButtonWithDefaults skin={skin}/>);
         expect(driver.getSkin()).toBe(skin);
       });
     });
   });
 
   describe('priority prop', () => {
-    it(`should be '${Priority.primary}' by default`, () => {
-      const driver = createDriver(<PButton/>);
+    it('should be primary by default', () => {
+      const driver = createDriver(<ButtonWithDefaults/>);
       expect(driver.getPriority()).toBe(Priority.primary);
     });
 
     enumValues(Priority).forEach((priority: Priority) => {
       it(`should be '${priority}'`, () => {
-        const driver = createDriver(<PButton priority={priority}/>);
+        const driver = createDriver(<ButtonWithDefaults priority={priority}/>);
         expect(driver.getPriority()).toBe(priority);
       });
     });
   });
 
   describe('size prop', () => {
-    it(`should be '${Size.medium}' by default`, () => {
-      const driver = createDriver(<PButton/>);
+    it('should be medium by default', () => {
+      const driver = createDriver(<ButtonWithDefaults/>);
       expect(driver.getSize()).toBe(Size.medium);
     });
 
     enumValues(Size).forEach((size: Size) => {
       it(`should be '${size}'`, () => {
-        const driver = createDriver(<PButton size={size}/>);
+        const driver = createDriver(<ButtonWithDefaults size={size}/>);
         expect(driver.getSize()).toBe(size);
       });
     });
@@ -72,7 +71,7 @@ describe('Button', () => {
  * Create a Component with applied default props.
  * The new component can receive Partial<P> instead of P.
  */
-function partialHOC<P>(Component: React.SFC<P>, defaultProps: P): React.SFC<Partial<P>> {
+function withDefaultsHOC<P>(Component: React.SFC<P>, defaultProps: P): React.SFC<Partial<P>> {
   return (partialProps?: Partial<P>) => {
     return React.createElement(Component, defaults({}, partialProps, defaultProps));
   }

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -1,14 +1,79 @@
 import * as React from 'react';
-import {Button} from './';
+import defaults = require('lodash/defaults');
+import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
+import { buttonDriverFactory } from "./Button.driver";
 import {buttonTestkitFactory} from '../../testkit';
 import {buttonTestkitFactory as enzymeButtonTestkitFactory} from '../../testkit/enzyme';
 import {runTestkitExistsSuite} from '../../common/testkitTests';
+import {Button,ButtonProps} from './';
+import {Skin, Priority, Size} from './constants';
+import { enumValues } from '../../utils';
+
 
 describe('Button', () => {
+  const createDriver = createDriverFactory(buttonDriverFactory);
+  const PButton = partialHOC(Button, 
+    {
+      children: 'Click me!'
+    });
 
+  describe('skin prop', () => {
+    it(`should be '${Skin.standard}' by default`, () => {
+      const driver = createDriver(<PButton/>);
+      expect(driver.getSkin()).toBe(Skin.standard);
+    });
+
+    enumValues(Skin).forEach((skin: Skin) => {
+      it(`should be '${skin}'`, () => {
+        const driver = createDriver(<PButton skin={skin}/>);
+        expect(driver.getSkin()).toBe(skin);
+      });
+    });
+  });
+
+  describe('priority prop', () => {
+    it(`should be '${Priority.primary}' by default`, () => {
+      const driver = createDriver(<PButton/>);
+      expect(driver.getPriority()).toBe(Priority.primary);
+    });
+
+    enumValues(Priority).forEach((priority: Priority) => {
+      it(`should be '${priority}'`, () => {
+        const driver = createDriver(<PButton priority={priority}/>);
+        expect(driver.getPriority()).toBe(priority);
+      });
+    });
+  });
+
+  describe('size prop', () => {
+    it(`should be '${Size.medium}' by default`, () => {
+      const driver = createDriver(<PButton/>);
+      expect(driver.getSize()).toBe(Size.medium);
+    });
+
+    enumValues(Size).forEach((size: Size) => {
+      it(`should be '${size}'`, () => {
+        const driver = createDriver(<PButton size={size}/>);
+        expect(driver.getSize()).toBe(size);
+      });
+    });
+  });
+  
   runTestkitExistsSuite({
     Element: <Button/>,
     testkitFactory: buttonTestkitFactory,
     enzymeTestkitFactory: enzymeButtonTestkitFactory
   });
 });
+
+
+// TODO: consider putting this in 'test/utils'
+/**
+ * Create a Component with applied default props.
+ * The new component can receive Partial<P> instead of P.
+ */
+function partialHOC<P>(Component: React.SFC<P>, defaultProps: P): React.SFC<Partial<P>> {
+  return (partialProps?: Partial<P>) => {
+    return React.createElement(Component, defaults({}, partialProps, defaultProps));
+  }
+}

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -7,7 +7,7 @@ import {buttonTestkitFactory as enzymeButtonTestkitFactory} from '../../testkit/
 import {runTestkitExistsSuite} from '../../common/testkitTests';
 import {Button,ButtonProps} from './';
 import {Skin, Priority, Size} from './constants';
-import { enumValues } from '../../utils';
+import {enumValues} from '../../utils';
 
 
 describe('Button', () => {

--- a/src/components/Button/Button.st.css
+++ b/src/components/Button/Button.st.css
@@ -3,6 +3,28 @@
   -st-default: Button;
 }
 
+:import {
+  -st-from: "../../palette.st.css";
+  -st-named: main;
+}
 .root {
   -st-extends: Button;
+  -st-states: skin(enum(standard)), priority(enum(primary)), size(enum(medium));
+
+  box-sizing: border-box;
+  
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.root:skin(standard):priority(primary) {
+  background-color: value(main);
+  border-color: value(main);
+}
+
+.root:size(medium) {
+  width: 95px;
+  height: 36px;
+  border-radius: 18px;
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,12 +1,42 @@
 import * as React from 'react';
+import { string } from "prop-types";
 import {Button as CoreButton, ButtonProps as CoreButtonProps} from 'wix-ui-core/Button';
 import style from './Button.st.css';
 import {withStylable} from 'wix-ui-core/withStylable';
 
-export interface ButtonProps extends CoreButtonProps {}
+export interface ButtonOwnProps extends CoreButtonProps {
+  skin?: 'standard';
+  priority?: 'primary';
+  size?: 'medium';
+}
 
-export const Button = withStylable<CoreButtonProps, {}>(
-  CoreButton,
-  style,
-  () => null
-);
+const defaultProps :Partial<CoreButtonProps & ButtonOwnProps> ={
+  skin: 'standard',
+  priority: 'primary',
+  size: 'medium'
+}
+
+export type ButtonProps = ButtonOwnProps & CoreButtonProps;
+
+export const Button : React.SFC<ButtonProps> = props => {
+  const {children, skin, priority, size, ...rest} = props;
+
+  return (
+    <CoreButton 
+      {...rest}
+      {...style('root',{skin,priority,size}, rest)}
+    >
+      {children}
+    </CoreButton>
+  )
+}
+
+Button.defaultProps = defaultProps;
+
+Button.propTypes =  {
+  skin: string,
+  priority: string,
+  size: string
+}
+
+

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { oneOf } from "prop-types";
+import {oneOf} from "prop-types";
 import {Button as CoreButton, ButtonProps as CoreButtonProps} from 'wix-ui-core/Button';
 import {withStylable} from 'wix-ui-core/withStylable';
-import { enumValues } from '../../utils';
+import {enumValues} from '../../utils';
 import style from './Button.st.css';
 import {Skin, Priority, Size} from './constants';
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { oneOf } from "prop-types";
 import {Button as CoreButton, ButtonProps as CoreButtonProps} from 'wix-ui-core/Button';
-import style from './Button.st.css';
 import {withStylable} from 'wix-ui-core/withStylable';
-import {Skin, Priority, Size} from './constants';
 import { enumValues } from '../../utils';
+import style from './Button.st.css';
+import {Skin, Priority, Size} from './constants';
 
 export interface ButtonOwnProps extends CoreButtonProps {
   /**Skin of the Button (Styling)*/

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,19 +1,18 @@
 import * as React from 'react';
-import { string } from "prop-types";
+import { oneOf } from "prop-types";
 import {Button as CoreButton, ButtonProps as CoreButtonProps} from 'wix-ui-core/Button';
 import style from './Button.st.css';
 import {withStylable} from 'wix-ui-core/withStylable';
+import {Skin, Priority, Size} from './constants';
+import { enumValues } from '../../utils';
 
 export interface ButtonOwnProps extends CoreButtonProps {
-  skin?: 'standard';
-  priority?: 'primary';
-  size?: 'medium';
-}
-
-const defaultProps :Partial<CoreButtonProps & ButtonOwnProps> ={
-  skin: 'standard',
-  priority: 'primary',
-  size: 'medium'
+  /**Skin of the Button (Styling)*/
+  skin?: Skin;
+  /** Priority of the Button (Styling)*/
+  priority?: Priority;
+  /** Size of the button (Styling) */
+  size?: Size;
 }
 
 export type ButtonProps = ButtonOwnProps & CoreButtonProps;
@@ -24,19 +23,23 @@ export const Button : React.SFC<ButtonProps> = props => {
   return (
     <CoreButton 
       {...rest}
-      {...style('root',{skin,priority,size}, rest)}
+      {...style('root',{skin, priority, size}, rest)}
     >
       {children}
     </CoreButton>
   )
 }
 
-Button.defaultProps = defaultProps;
+Button.defaultProps = {
+  skin: Skin.standard,
+  priority: Priority.primary,
+  size: Size.medium
+}
 
 Button.propTypes =  {
-  skin: string,
-  priority: string,
-  size: string
+  skin: oneOf(enumValues(Skin)),
+  priority: oneOf(enumValues(Priority)),
+  size: oneOf(enumValues(Size))
 }
 
 

--- a/src/components/Button/constants.ts
+++ b/src/components/Button/constants.ts
@@ -1,0 +1,12 @@
+export enum Skin {
+  standard= 'standard',
+};
+
+export enum Priority  {
+  primary= 'primary',
+};
+
+export enum Size {
+  medium = 'medium',
+  small = 'small'
+}

--- a/src/components/Button/constants.ts
+++ b/src/components/Button/constants.ts
@@ -8,5 +8,4 @@ export enum Priority  {
 
 export enum Size {
   medium = 'medium',
-  small = 'small'
 }

--- a/src/testkit/enzyme.ts
+++ b/src/testkit/enzyme.ts
@@ -9,8 +9,9 @@ export const badgeTestkitFactory = enzymeTestkitFactoryCreator(badgeDriverFactor
 import {headingDriverFactory} from '../components/Heading/Heading.driver';
 export const headingTestkitFactory = enzymeTestkitFactoryCreator(headingDriverFactory);
 
-import {buttonDriverFactory} from '../components/Button/Button.driver';
+import {buttonDriverFactory, ButtonDriver} from '../components/Button/Button.driver';
 export const buttonTestkitFactory = enzymeTestkitFactoryCreator(buttonDriverFactory);
+export {ButtonDriver};
 
 import {checkboxDriverFactory} from '../components/Checkbox/Checkbox.driver';
 export const checkboxTestkitFactory = enzymeTestkitFactoryCreator(checkboxDriverFactory);

--- a/src/testkit/index.ts
+++ b/src/testkit/index.ts
@@ -9,8 +9,9 @@ export const badgeTestkitFactory = testkitFactoryCreator(badgeDriverFactory);
 import {headingDriverFactory} from '../components/Heading/Heading.driver';
 export const headingTestkitFactory = testkitFactoryCreator(headingDriverFactory);
 
-import {buttonDriverFactory} from '../components/Button/Button.driver';
+import {buttonDriverFactory, ButtonDriver} from '../components/Button/Button.driver';
 export const buttonTestkitFactory = testkitFactoryCreator(buttonDriverFactory);
+export {ButtonDriver};
 
 import {checkboxDriverFactory} from '../components/Checkbox/Checkbox.driver';
 export const checkboxTestkitFactory = testkitFactoryCreator(checkboxDriverFactory);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,8 @@ export const hexToRgba = (hex, opacity) => {
   const b = parseInt(hex.substring(5, 7), 16);
   return `rgba(${r}, ${g}, ${b}, ${opacity})`;
 };
+
+export function enumValues(e: object) {
+  return Object.keys(e).map(k => e[k as any]);
+}
+

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,8 +1,19 @@
-import {hexToRgba} from './';
+import {hexToRgba, enumValues} from './';
 
 describe('hexToRgba function', () => {
   it('should transform hex to Rgba', () => {
     const opacity = 0;
     expect(hexToRgba('#4af441', opacity)).toBe(`rgba(74, 244, 65, ${opacity})`);
+  });
+});
+
+describe('enumValues function', () => {
+  
+  it('should list enum values', () => {
+    enum Foo {
+      AAA= "aaa",
+      BBB= "bbb"
+    }
+    expect(enumValues(Foo)).toEqual(['aaa','bbb']);
   });
 });


### PR DESCRIPTION
According to spec:
https://app.zeplin.io/project/5864e02695b5754a69f56150/screen/5ae6dfe664ab672128d5b6ac

- Only added  the default values : 
skin: standard
priority: primary
size: medium

- Only added styling for the default props.

- Still not using `<Text>`

- eyes should break 