### PR TITLE
<FloatingHelper> - Add internal <ClosablePopover> and use it instead of <Popover>

### DIFF
--- a/src/components/CloseButton/CloseButton.spec.tsx
+++ b/src/components/CloseButton/CloseButton.spec.tsx
@@ -1,30 +1,30 @@
 import * as React from 'react';
 import defaults = require('lodash/defaults');
-import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {closeButtonDriverFactory} from "./CloseButton.driver";
-import {closeButtonTestkitFactory} from '../../testkit';
-import {closeButtonTestkitFactory as enzymeCloseButtonTestkitFactory} from '../../testkit/enzyme';
-import {runTestkitExistsSuite} from '../../common/testkitTests';
-import {CloseButton,CloseButtonProps} from './CloseButton';
-import {Skin, Size} from './constants';
-import {enumValues} from '../../utils';
+import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { closeButtonDriverFactory } from './CloseButton.driver';
+import { closeButtonTestkitFactory } from '../../testkit';
+import { closeButtonTestkitFactory as enzymeCloseButtonTestkitFactory } from '../../testkit/enzyme';
+import { runTestkitExistsSuite } from '../../common/testkitTests';
+import { CloseButton, CloseButtonProps } from './CloseButton';
+import { Skin, Size } from './constants';
+import { enumValues } from '../../utils';
 
 describe('CloseButton', () => {
   const createDriver = createDriverFactory(closeButtonDriverFactory);
-  const CloseButtonWithDefaults = withDefaultsHOC(CloseButton, 
+  const CloseButtonWithDefaults = withDefaultsHOC(CloseButton,
     {
       children: 'Click me!'
     });
 
   describe('skin prop', () => {
     it('should be standard by default', () => {
-      const driver = createDriver(<CloseButtonWithDefaults/>);
+      const driver = createDriver(<CloseButtonWithDefaults />);
       expect(driver.getSkin()).toBe(Skin.standard);
     });
 
     enumValues(Skin).forEach((skin: Skin) => {
       it(`should be '${skin}'`, () => {
-        const driver = createDriver(<CloseButtonWithDefaults skin={skin}/>);
+        const driver = createDriver(<CloseButtonWithDefaults skin={skin} />);
         expect(driver.getSkin()).toBe(skin);
       });
     });
@@ -32,20 +32,20 @@ describe('CloseButton', () => {
 
   describe('size prop', () => {
     it('should be small by default', () => {
-      const driver = createDriver(<CloseButtonWithDefaults/>);
+      const driver = createDriver(<CloseButtonWithDefaults />);
       expect(driver.getSize()).toBe(Size.small);
     });
 
     enumValues(Size).forEach((size: Size) => {
       it(`should be '${size}'`, () => {
-        const driver = createDriver(<CloseButtonWithDefaults size={size}/>);
+        const driver = createDriver(<CloseButtonWithDefaults size={size} />);
         expect(driver.getSize()).toBe(size);
       });
     });
   });
-  
+
   runTestkitExistsSuite({
-    Element: <CloseButton/>,
+    Element: <CloseButton />,
     testkitFactory: closeButtonTestkitFactory,
     enzymeTestkitFactory: enzymeCloseButtonTestkitFactory
   });

--- a/src/components/CloseButton/CloseButton.tsx
+++ b/src/components/CloseButton/CloseButton.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import {oneOf} from "prop-types";
-import {Button as CoreButton, ButtonProps as CoreButtonProps} from 'wix-ui-core/Button';
-import {enumValues} from '../../utils';
+import { oneOf } from 'prop-types';
+import { Button as CoreButton, ButtonProps as CoreButtonProps } from 'wix-ui-core/Button';
+import { enumValues } from '../../utils';
 import style from './CloseButton.st.css';
-import {Skin, Size} from './constants';
-import {Close as CloseIcon} from 'wix-ui-icons-common/system';
+import { Skin, Size } from './constants';
+import { Close as CloseIcon } from 'wix-ui-icons-common/system';
 
 export interface CloseButtonOwnProps extends CoreButtonProps {
   /**Skin of the Button (Styling)*/
@@ -15,16 +15,16 @@ export interface CloseButtonOwnProps extends CoreButtonProps {
 
 export type CloseButtonProps = CloseButtonOwnProps & CoreButtonProps;
 
-export const CloseButton : React.SFC<CloseButtonProps> = props => {
+export const CloseButton: React.SFC<CloseButtonProps> = props => {
   // children is ommited on purpose (and not used)
-  const {children, skin, size, ...rest} = props;
+  const { children, skin, size, ...rest } = props;
 
   return (
-    <CoreButton 
+    <CoreButton
       {...rest}
-      {...style('root',{skin, size}, rest)}
+      {...style('root', { skin, size }, rest)}
     >
-      <CloseIcon/>
+      <CloseIcon />
     </CoreButton>
   )
 }
@@ -34,7 +34,7 @@ CloseButton.defaultProps = {
   size: Size.small
 }
 
-CloseButton.propTypes =  {
+CloseButton.propTypes = {
   skin: oneOf(enumValues(Skin)),
   size: oneOf(enumValues(Size)),
   // TODO: can we validate here that children is NOT defined?

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.driver.ts
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.driver.ts
@@ -1,16 +1,17 @@
-import {BaseDriver, DriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {popoverDriverFactory} from 'wix-ui-core/dist/src/components/Popover/Popover.driver';
+import { BaseDriver, DriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { popoverDriverFactory } from 'wix-ui-core/dist/src/components/Popover/Popover.driver';
 
 // TODO: add interface of PopoverDriver (not defined yet in the core)
 export interface ClosablePopoverDriver extends BaseDriver {
+  /** Checks is the popover's content is open */
   isOpened: () => boolean;
 }
 
-export const closablePopoverDriverFactory: DriverFactory<ClosablePopoverDriver>  =  ({element, eventTrigger}) => {
-  const popoverDriver = popoverDriverFactory({element, eventTrigger});
+export const closablePopoverDriverFactory: DriverFactory<ClosablePopoverDriver> = ({ element, eventTrigger }) => {
+  const popoverDriver = popoverDriverFactory({ element, eventTrigger });
 
   return {
     ...popoverDriver,
-    isOpened: ()=> popoverDriver.isContentElementExists()
+    isOpened: () => popoverDriver.isContentElementExists()
   };
 };

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.driver.ts
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.driver.ts
@@ -1,0 +1,16 @@
+import {BaseDriver, DriverFactory} from 'wix-ui-test-utils/driver-factory';
+import {popoverDriverFactory} from 'wix-ui-core/dist/src/components/Popover/Popover.driver';
+
+// TODO: add interface of PopoverDriver (not defined yet in the core)
+export interface ClosablePopoverDriver extends BaseDriver {
+  isOpened: () => boolean;
+}
+
+export const closablePopoverDriverFactory: DriverFactory<ClosablePopoverDriver>  =  ({element, eventTrigger}) => {
+  const popoverDriver = popoverDriverFactory({element, eventTrigger});
+
+  return {
+    ...popoverDriver,
+    isOpened: ()=> popoverDriver.isContentElementExists()
+  };
+};

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
+import {isTestkitExists} from 'wix-ui-test-utils/vanilla';
+import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
+
+import {closablePopoverDriverFactory, ClosablePopoverDriver} from './ClosablePopover.driver';
+import {ClosablePopover, ClosablePopoverProps} from './ClosablePopover';
+import defaults = require('lodash/defaults');
+
+describe('FloatingHelper', () => {
+  const createDriver = createDriverFactory(closablePopoverDriverFactory);
+  const createComponent= (partialProps?: Partial<ClosablePopoverProps>) => (
+    <ClosablePopover
+      target={<div>this is the target</div>}
+      content={()=><div>this is the popover content</div>}
+      placement='right'
+      {...partialProps}
+    />
+  )
+  describe('close', () => {
+    it('should be opened by default', () => {
+      const driver = createDriver(createComponent());
+      expect(driver.isOpened()).toBeTruthy();
+    });
+
+    it('should close when closeAction called', () => {
+      let triggerClose;
+      const driver = createDriver(createComponent({content: ({close}) => {
+        triggerClose = close;
+        return <div>the content</div>;
+      }}));
+      expect(driver.isOpened()).toBeTruthy();
+      triggerClose();
+      expect(driver.isOpened()).toBeFalsy();
+    });
+  });
+
+});

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
-import {mount} from 'enzyme';
-import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {isTestkitExists} from 'wix-ui-test-utils/vanilla';
-import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
+import { mount } from 'enzyme';
+import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { isTestkitExists } from 'wix-ui-test-utils/vanilla';
+import { isEnzymeTestkitExists } from 'wix-ui-test-utils/enzyme';
 
-import {closablePopoverDriverFactory, ClosablePopoverDriver} from './ClosablePopover.driver';
-import {ClosablePopover, ClosablePopoverProps} from './ClosablePopover';
+import { closablePopoverDriverFactory, ClosablePopoverDriver } from './ClosablePopover.driver';
+import { ClosablePopover, ClosablePopoverProps } from './ClosablePopover';
 import defaults = require('lodash/defaults');
 
 describe('ClosablePopover', () => {
   const createDriver = createDriverFactory(closablePopoverDriverFactory);
-  const createComponent= (partialProps?: Partial<ClosablePopoverProps>) => (
+  const createComponent = (partialProps?: Partial<ClosablePopoverProps>) => (
     <ClosablePopover
       target={<div>this is the target</div>}
-      content={()=><div>this is the popover content</div>}
-      placement='right'
+      content={() => <div>this is the popover content</div>}
+      placement="right"
       {...partialProps}
     />
   )
@@ -26,10 +26,12 @@ describe('ClosablePopover', () => {
 
     it('should close when closeAction called', () => {
       let triggerClose;
-      const driver = createDriver(createComponent({content: ({close}) => {
-        triggerClose = close;
-        return <div>the content</div>;
-      }}));
+      const driver = createDriver(createComponent({
+        content: ({ close }) => {
+          triggerClose = close;
+          return <div>the content</div>;
+        }
+      }));
       expect(driver.isOpened()).toBeTruthy();
       triggerClose();
       expect(driver.isOpened()).toBeFalsy();

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -8,7 +8,7 @@ import {closablePopoverDriverFactory, ClosablePopoverDriver} from './ClosablePop
 import {ClosablePopover, ClosablePopoverProps} from './ClosablePopover';
 import defaults = require('lodash/defaults');
 
-describe('FloatingHelper', () => {
+describe('ClosablePopover', () => {
   const createDriver = createDriverFactory(closablePopoverDriverFactory);
   const createComponent= (partialProps?: Partial<ClosablePopoverProps>) => (
     <ClosablePopover

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import {Requireable, bool, func, node} from "prop-types";
+import isBoolean = require('lodash/isBoolean');
+import pick = require('lodash/pick');
+import { Popover, PopoverProps } from 'wix-ui-core/Popover';
+
+const noop = () => void 0;
+
+export interface ClosableActions {
+  /** Closes the popover content*/
+  close: () => void;
+}
+
+export interface ClosableProps {
+  /** Controls wether the popover's content is shown or not. 
+   * When undefined, then the component is Uncontrolled,
+   * It is initially open, and it can be closed by close-action */
+  opened?: boolean;
+  /** Called when the popover's content is closed. (Either by clicking on the close-button, click out-side, or by the close action) */
+  onClose?: () => void;
+  content: (closable: ClosableActions) => React.ReactNode;
+  target: React.ReactNode;
+}
+
+export interface ClosablePopoverState {
+  opened?: boolean;
+}
+
+const pickedPopoverPropTypes = pick(Popover.propTypes, ['className', 'placement', 'showArrow', 'moveBy', 'hideDelay', 'showDelay', 'moveArrowTo', 'appendTo', 'timeout']);
+export type PickedPopoverProps = Pick<PopoverProps,     'className'| 'placement'| 'showArrow'| 'moveBy'| 'hideDelay'| 'showDelay'| 'moveArrowTo'| 'appendTo'| 'timeout'>;
+
+export type ClosablePopoverProps = PickedPopoverProps & ClosableProps;
+
+/**
+ * Closable Popover
+ * Either a normal Controlled Popover, or a Popover that is inittialy opened and can be the closed by
+ * calling a closeAction.
+ */
+export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, ClosablePopoverState> {
+  state: ClosablePopoverState = {opened:true};
+
+  static propTypes: React.ValidationMap<ClosablePopoverProps> = {
+    ...pickedPopoverPropTypes,
+    opened: bool,
+    onClose: func,
+    content: func,
+    target: node
+  };
+
+  get isControlled() {
+    return isBoolean(this.props.opened);
+  }
+
+  render() {
+    const open = this.isControlled ? this.props.opened : this.state.opened;
+    // const popoverProps = pick(this.props, ['className', 'placement', 'showArrow', 'moveBy', 'hideDelay', 'showDelay', 'moveArrowTo', 'appendTo', 'timeout']);
+    const {opened, onClose, content, target, children, ...rest} = this.props;
+
+    // Using createElement() in order to get ts props validation.
+    return React.createElement(Popover,{shown: open, ...rest},(
+      <Popover.Element>
+          {target}
+        </Popover.Element>
+      ),(
+      <Popover.Content>
+        {content(this.actions)}
+      </Popover.Content>
+      )
+    );
+  }
+  
+  public close = ()=> {
+    if (this.isControlled) {
+       throw new Error('ClosablePopover.close() can not be called when component is Controlled. (opened prop should be undefined)');
+    }
+    if (this.state.opened) {
+      this.setState({ opened: false }, () => {
+        this.props.onClose && this.props.onClose();
+      });
+    }
+  }
+
+  actions: ClosableActions = {
+    close: this.close,
+  };
+};

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Requireable, bool, func, node } from "prop-types";
+import { Requireable, bool, func, node } from 'prop-types';
 import isBoolean = require('lodash/isBoolean');
 import pick = require('lodash/pick');
 import { Popover, PopoverProps } from 'wix-ui-core/Popover';

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -1,22 +1,20 @@
 import * as React from 'react';
-import {Requireable, bool, func, node} from "prop-types";
+import { Requireable, bool, func, node } from "prop-types";
 import isBoolean = require('lodash/isBoolean');
 import pick = require('lodash/pick');
 import { Popover, PopoverProps } from 'wix-ui-core/Popover';
 
-export interface ClosableActions {
+export interface ClosablePopoverActions {
   /** Closes the popover content*/
   close: () => void;
 }
 
-export interface ClosableProps {
+export interface ClosablePopoverOwnProps {
   /** Controls wether the popover's content is shown or not. 
    * When undefined, then the component is Uncontrolled,
    * It is initially open, and it can be closed by close-action */
   opened?: boolean;
-  /** Called when the popover's content is closed. (Either by clicking on the close-button, click out-side, or by the close action) */
-  onClose?: () => void;
-  content: (closable: ClosableActions) => React.ReactNode;
+  content: (closable: ClosablePopoverActions) => React.ReactNode;
   target: React.ReactNode;
 }
 
@@ -25,9 +23,9 @@ export interface ClosablePopoverState {
 }
 
 const pickedPopoverPropTypes = pick(Popover.propTypes, ['className', 'placement', 'showArrow', 'moveBy', 'hideDelay', 'showDelay', 'moveArrowTo', 'appendTo', 'timeout']);
-export type PickedPopoverProps = Pick<PopoverProps,     'className'| 'placement'| 'showArrow'| 'moveBy'| 'hideDelay'| 'showDelay'| 'moveArrowTo'| 'appendTo'| 'timeout'>;
+export type PickedPopoverProps = Pick<PopoverProps, 'className' | 'placement' | 'showArrow' | 'moveBy' | 'hideDelay' | 'showDelay' | 'moveArrowTo' | 'appendTo' | 'timeout'>;
 
-export type ClosablePopoverProps = PickedPopoverProps & ClosableProps;
+export type ClosablePopoverProps = PickedPopoverProps & ClosablePopoverOwnProps;
 
 /**
  * Closable Popover
@@ -35,12 +33,11 @@ export type ClosablePopoverProps = PickedPopoverProps & ClosableProps;
  * calling a closeAction.
  */
 export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, ClosablePopoverState> {
-  state: ClosablePopoverState = {opened:true};
+  state: ClosablePopoverState = { opened: true };
 
   static propTypes: React.ValidationMap<ClosablePopoverProps> = {
     ...pickedPopoverPropTypes,
     opened: bool,
-    onClose: func,
     content: func,
     target: node
   };
@@ -50,35 +47,33 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
   }
 
   render() {
+    // NOTE: we can not use pick, since there are unknown 'data-*' props coming from 
+    // Stylabel (and the data-hook also). Also some variable constants are destructed from props
+    // only to be 'omit' and are not in use. (Using lodash.omit is not type safe)
+    const { opened, content, target, children, ...rest } = this.props;
     const open = this.isControlled ? this.props.opened : this.state.opened;
-    // const popoverProps = pick(this.props, ['className', 'placement', 'showArrow', 'moveBy', 'hideDelay', 'showDelay', 'moveArrowTo', 'appendTo', 'timeout']);
-    const {opened, onClose, content, target, children, ...rest} = this.props;
 
     // Using createElement() in order to get ts props validation.
-    return React.createElement(Popover,{shown: open, ...rest},(
+    return React.createElement(Popover, { shown: open, ...rest }, (
       <Popover.Element>
-          {target}
-        </Popover.Element>
-      ),(
-      <Popover.Content>
-        {content(this.actions)}
-      </Popover.Content>
+        {target}
+      </Popover.Element>
+    ), (
+        <Popover.Content>
+          {content(this.actions)}
+        </Popover.Content>
       )
     );
   }
-  
-  public close = ()=> {
+
+  public close = () => {
     if (this.isControlled) {
-       throw new Error('ClosablePopover.close() can not be called when component is Controlled. (opened prop should be undefined)');
+      throw new Error('ClosablePopover.close() can not be called when component is Controlled. (opened prop should be undefined)');
     }
-    if (this.state.opened) {
-      this.setState({ opened: false }, () => {
-        this.props.onClose && this.props.onClose();
-      });
-    }
+    this.state.opened && this.setState({ opened: false });
   }
 
-  actions: ClosableActions = {
+  actions: ClosablePopoverActions = {
     close: this.close,
   };
 };

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -4,8 +4,6 @@ import isBoolean = require('lodash/isBoolean');
 import pick = require('lodash/pick');
 import { Popover, PopoverProps } from 'wix-ui-core/Popover';
 
-const noop = () => void 0;
-
 export interface ClosableActions {
   /** Closes the popover content*/
   close: () => void;

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -14,7 +14,11 @@ export interface ClosablePopoverOwnProps {
    * When undefined, then the component is Uncontrolled,
    * It is initially open, and it can be closed by close-action */
   opened?: boolean;
+  /** The popover's content, given as a function that receives control-actions and renders the contet.
+   * In Uncontrolled mode, this function is still called only once.
+  */
   content: (closable: ClosablePopoverActions) => React.ReactNode;
+  /** The popover's target element*/
   target: React.ReactNode;
 }
 

--- a/src/components/FloatingHelper/ClosablePopover/index.ts
+++ b/src/components/FloatingHelper/ClosablePopover/index.ts
@@ -1,0 +1,1 @@
+export * from './ClosablePopover';

--- a/src/components/FloatingHelper/FloatingHelper.driver.ts
+++ b/src/components/FloatingHelper/FloatingHelper.driver.ts
@@ -1,15 +1,18 @@
 import {BaseDriver, DriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {popoverDriverFactory} from 'wix-ui-core/dist/src/components/Popover/Popover.driver';
+import {closablePopoverDriverFactory,ClosablePopoverDriver} from './ClosablePopover/ClosablePopover.driver';
 import {DataHooks} from './DataHooks';
 import {helperContentDriverFactory, HelperContentDriver} from '../../components/FloatingHelper/HelperContent/HelperContent.driver';
-import {EnzymeDriverFactory} from 'wix-ui-test-utils/enzyme';
 
 // TODO: add interface of PopoverDriver
-export interface FloatingHelperDriver extends BaseDriver {
+export interface FloatingHelperDriver extends ClosablePopoverDriver {
   /** Get the driver for the helper's content */
   getHelperContentDriver: () => HelperContentDriver;
   /** check wether the helper has a close button */
   hasCloseButton: () => boolean;
+  /** click the close button */
+  clickCloseButton: () => void;
+  /** check wether the helper content is shown */
+  isOpened: () => boolean;
   /** Get width of content's root element */
   getWidth: () => string;
 }
@@ -20,13 +23,13 @@ export const floatingHelperDriverFactory:
   const innerContent = () => element.querySelector(`[data-hook='${DataHooks.innerContent}']`);
   const closeButton = () => element.querySelector(`[data-hook='${DataHooks.closeButton}']`);
   const contentWrapper = () => element.querySelector(`[data-hook='${DataHooks.contentWrapper}']`);
+  const closablePopoverDriver = closablePopoverDriverFactory({wrapper, element, eventTrigger});
 
   return {
-    ...popoverDriverFactory({element, eventTrigger}),
+    ...closablePopoverDriver,
     hasCloseButton: () => !!closeButton(),
-    /** Get HelperContent driver */
+    clickCloseButton: () => eventTrigger.click(closeButton()),
     getHelperContentDriver: () => helperContentDriverFactory({wrapper, element: innerContent(), eventTrigger}),
-    /** returns the width of the coomponent */
     getWidth: () => window.getComputedStyle(contentWrapper()).width
   };
 };

--- a/src/components/FloatingHelper/FloatingHelper.spec.tsx
+++ b/src/components/FloatingHelper/FloatingHelper.spec.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import {mount} from 'enzyme';
-import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {isTestkitExists} from 'wix-ui-test-utils/vanilla';
-import {isEnzymeTestkitExists} from 'wix-ui-test-utils/enzyme';
-import {floatingHelperTestkitFactory} from '../../testkit';
-import {floatingHelperTestkitFactory as enzymeFloatingHelperTestkitFactory} from '../../testkit/enzyme';
-import {floatingHelperDriverFactory, FloatingHelperDriver} from './FloatingHelper.driver';
-import {FloatingHelper, FloatingHelperProps} from './FloatingHelper';
-import {HelperContent, HelperContentProps} from '../../components/FloatingHelper/HelperContent';
+import { mount } from 'enzyme';
+import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { isTestkitExists } from 'wix-ui-test-utils/vanilla';
+import { isEnzymeTestkitExists } from 'wix-ui-test-utils/enzyme';
+import { floatingHelperTestkitFactory } from '../../testkit';
+import { floatingHelperTestkitFactory as enzymeFloatingHelperTestkitFactory } from '../../testkit/enzyme';
+import { floatingHelperDriverFactory, FloatingHelperDriver } from './FloatingHelper.driver';
+import { FloatingHelper, FloatingHelperProps } from './FloatingHelper';
+import { HelperContent, HelperContentProps } from '../../components/FloatingHelper/HelperContent';
 import defaults = require('lodash/defaults');
 
 describe('FloatingHelper', () => {
@@ -15,13 +15,12 @@ describe('FloatingHelper', () => {
 
   const buildComponent = (props?: Partial<FloatingHelperProps>) => {
     const defaultProps: FloatingHelperProps = {
-      shown: true,
       placement: 'right',
-      content: <HelperContent title="my title"/>,
+      content: <HelperContent title="my title" />,
       children: <div>This is the target element</div>
     };
 
-    return <FloatingHelper {...defaults({}, props, defaultProps)}/>;
+    return <FloatingHelper {...defaults({}, props, defaultProps)} />;
   };
 
   // Skipped: need to add hasArrow() method to Popover driver.
@@ -44,13 +43,13 @@ describe('FloatingHelper', () => {
 
     it('should have a custom width (which is a string)', () => {
       const width = '500px';
-      const driver = createDriver(buildComponent({width}));
+      const driver = createDriver(buildComponent({ width }));
       expect(driver.getWidth()).toBe(width);
     });
 
     it('should have a custom width (which is a number)', () => {
       const width = 600;
-      const driver = createDriver(buildComponent({width}));
+      const driver = createDriver(buildComponent({ width }));
       expect(driver.getWidth()).toBe(`${width}px`);
     });
   });
@@ -62,8 +61,21 @@ describe('FloatingHelper', () => {
     });
 
     it('should NOT have a close-button', () => {
-      const driver = createDriver(buildComponent({showCloseButton: false}));
+      const driver = createDriver(buildComponent({ showCloseButton: false }));
       expect(driver.hasCloseButton()).toBeFalsy();
+    });
+  });
+
+  describe('close', () => {
+    it('should be opened by default', () => {
+      const driver = createDriver(buildComponent());
+      expect(driver.isOpened()).toBeTruthy();
+    });
+
+    it('should close popover when close-button is clicked', () => {
+      const driver = createDriver(buildComponent());
+      driver.clickCloseButton();
+      expect(driver.isOpened()).toBeFalsy();
     });
   });
 

--- a/src/components/FloatingHelper/FloatingHelper.tsx
+++ b/src/components/FloatingHelper/FloatingHelper.tsx
@@ -41,6 +41,8 @@ export const FloatingHelper: React.SFC<FloatingHelperProps> = props => {
       {showCloseButton && (
         <CloseButton
           className={style.closeButton}
+          data-hook={DataHooks.closeButton}
+          onClick={closableActions.close}
         />
       )}
       <div data-hook={DataHooks.innerContent} className={style.innerContent}>

--- a/src/components/FloatingHelper/FloatingHelper.tsx
+++ b/src/components/FloatingHelper/FloatingHelper.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import pick = require('lodash/pick');
 import { bool, string, number, oneOfType, node } from 'prop-types';
 import * as classnames from 'classnames';
-import { ClosablePopover, ClosablePopoverProps, ClosableActions } from './ClosablePopover';
+import { ClosablePopover, ClosablePopoverProps, ClosablePopoverActions } from './ClosablePopover';
 import { withStylable } from 'wix-ui-core/withStylable';
 import style from './FloatingHelper.st.css';
 import { DataHooks } from './DataHooks';
@@ -33,14 +33,12 @@ const pickedPopoverPropTypes = pick<
 export type FloatingHelperProps = PickedClosablePopoverProps & FloatingHelperOwnProps;
 
 export const FloatingHelper: React.SFC<FloatingHelperProps> = props => {
-  const { children, width, content, ...rest } = props;
+  const { children, width, content, showCloseButton, ...rest } = props;
   const contentWidth = (typeof width) === 'number' ? `${width}px` : width;
 
-  const closablePopoverProps: PickedClosablePopoverProps = pick(props, pickedPropNames);
-
-  const renderContent = (closableActions: ClosableActions) => (
+  const renderContent = (closableActions: ClosablePopoverActions) => (
     <div data-hook={DataHooks.contentWrapper} style={{ width: contentWidth }}>
-      {props.showCloseButton && (
+      {showCloseButton && (
         <CloseButton
           className={style.closeButton}
         />
@@ -56,7 +54,7 @@ export const FloatingHelper: React.SFC<FloatingHelperProps> = props => {
       showArrow
       target={children}
       content={renderContent}
-      {...closablePopoverProps}
+      {...rest}
       {...style('root', {}, props)}
     />
   );

--- a/src/components/FloatingHelper/FloatingHelper.tsx
+++ b/src/components/FloatingHelper/FloatingHelper.tsx
@@ -1,71 +1,64 @@
 import * as React from 'react';
 import pick = require('lodash/pick');
-import { bool, string, number, oneOfType } from 'prop-types';
+import { bool, string, number, oneOfType, node } from 'prop-types';
 import * as classnames from 'classnames';
-import { Popover, PopoverProps } from 'wix-ui-core/Popover';
+import { ClosablePopover, ClosablePopoverProps, ClosableActions } from './ClosablePopover';
 import { withStylable } from 'wix-ui-core/withStylable';
 import style from './FloatingHelper.st.css';
 import { DataHooks } from './DataHooks';
 import { Button } from '../Button';
+import { Skin, Size } from '../Button/constants';
 import { CloseButton } from '../CloseButton';
-import { Close as CloseIcon } from 'wix-ui-icons-common/system';
-import { Size, Skin } from '../CloseButton/constants';
-/**
- * Adapts Popover API with Popover.Element, and Popover.Content into regular props
- */
-export interface PopoverAdapterProps {
-  // TODO: should this be optional? if we expose 'appandTo' and 'appendToParent'?
-  /** children to render that will be the target of the tooltip */
-  children: React.ReactNode;
-  // TODO: add validation that it is a <HelperContent> component
-  /** the content to put inside the Popover. Should be a <HelperContent> component. */
-  content: React.ReactNode;
-}
 
 export interface FloatingHelperOwnProps {
   /** Controls wether a close button will appear ot not */
   showCloseButton?: boolean;
   /** Width HTML attribute of the content. If a number is passed then it defaults to px. e.g width={400} => width="400px" */
   width?: string | number;
+  /** The target of the popover */
+  children?: React.ReactNode
+  /** A <HelperContent> */
+  content: React.ReactNode
 }
 
-const PickedPopoverPropTypes = pick(Popover.propTypes, 'placement', 'shown', 'moveBy', 'hideDelay', 'showDelay', 'appendTo', 'timeout', 'className');
-export type PickedPopoverProps = Pick<PopoverProps, 'placement' | 'shown' | 'moveBy' | 'hideDelay' | 'showDelay' | 'appendTo' | 'timeout' | 'className'>;
-export type FloatingHelperProps = PickedPopoverProps & PopoverAdapterProps & FloatingHelperOwnProps;
+export type PickedClosablePopoverProps = Pick<ClosablePopoverProps,
+  'placement' | 'moveBy' | 'hideDelay' | 'showDelay' | 'appendTo' | 'timeout' | 'className'>;
+const pickedPropNames: Array<keyof PickedClosablePopoverProps> =
+  ['placement', 'moveBy', 'hideDelay', 'showDelay', 'appendTo', 'timeout', 'className'];
 
-const FloatingHelperBO = withStylable<PopoverProps, {}>(
-  Popover,
-  style,
-  p => ({})
-);
+const pickedPopoverPropTypes = pick<
+  typeof ClosablePopover.propTypes, keyof PickedClosablePopoverProps>(
+    ClosablePopover.propTypes, ...pickedPropNames);
+
+export type FloatingHelperProps = PickedClosablePopoverProps & FloatingHelperOwnProps;
 
 export const FloatingHelper: React.SFC<FloatingHelperProps> = props => {
-  const { children, content, width, ...rest } = props;
+  const { children, width, content, ...rest } = props;
   const contentWidth = (typeof width) === 'number' ? `${width}px` : width;
 
+  const closablePopoverProps: PickedClosablePopoverProps = pick(props, pickedPropNames);
+
+  const renderContent = (closableActions: ClosableActions) => (
+    <div data-hook={DataHooks.contentWrapper} style={{ width: contentWidth }}>
+      {props.showCloseButton && (
+        <CloseButton
+          className={style.closeButton}
+        />
+      )}
+      <div data-hook={DataHooks.innerContent} className={style.innerContent}>
+        {content}
+      </div>
+    </div>
+  )
+
   return (
-    <FloatingHelperBO
-      {...rest}
+    <ClosablePopover
       showArrow
-    >
-      <Popover.Element>
-        {children}
-      </Popover.Element>
-      <Popover.Content>
-        <div data-hook={DataHooks.contentWrapper} style={{ width: contentWidth }}>
-          {props.showCloseButton && (
-            <CloseButton
-              className={style.closeButton}
-              skin={Skin.white}
-              size={Size.large}
-            />
-          )}
-          <div data-hook={DataHooks.innerContent} className={style.innerContent}>
-            {content}
-          </div>
-        </div>
-      </Popover.Content>
-    </FloatingHelperBO>
+      target={children}
+      content={renderContent}
+      {...closablePopoverProps}
+      {...style('root', {}, props)}
+    />
   );
 };
 
@@ -75,7 +68,9 @@ FloatingHelper.defaultProps = {
 };
 
 FloatingHelper.propTypes = {
-  ...PickedPopoverPropTypes,
+  ...pickedPopoverPropTypes,
   showCloseButton: bool,
-  width: oneOfType([string, number])
+  width: oneOfType([string, number]),
+  children: node.isRequired,
+  content: node.isRequired // TODO: validate it is a <HelperContent>
 };

--- a/stories/FloatingHelper/FloatingHelper.story.tsx
+++ b/stories/FloatingHelper/FloatingHelper.story.tsx
@@ -25,7 +25,6 @@ export default {
 
   componentProps: {
     'data-hook': storySettings.dataHook,
-    shown: true,
     content: (
       <HelperContent
         title="This is the title"
@@ -52,7 +51,6 @@ function renderExample(dataHook: string, props?: Partial<FloatingHelperProps> ) 
     <div style={{marginTop: 150, marginBottom: 150}}>
       <FloatingHelper
         data-hook={dataHook}
-        shown
         placement="right"
         width="666px"
         content={<HelperContent/>}


### PR DESCRIPTION
- The ClosablePopover is currently implementing the behaviour required by the by the FloatingHelper. It is not yet a generic enough, but could be easily refactored in the future.
- The ClosablePopover API is inspired by https://github.com/wix/wix-ui/pull/417

- In FloatingHelper: I removed the use of `withStylable`