### PR TITLE
<HelperContent> - Add button theme (white or premium)

### DIFF
--- a/src/components/FloatingHelper/HelperContent/HelperContent.driver.ts
+++ b/src/components/FloatingHelper/HelperContent/HelperContent.driver.ts
@@ -1,5 +1,7 @@
-import {DataHooks} from './DataHooks';
-import {BaseDriver, DriverFactory} from 'wix-ui-test-utils/driver-factory';
+import { DataHooks } from './DataHooks';
+import { BaseDriver, DriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { buttonDriverFactory, ButtonDriver } from '../../Button/Button.driver';
+import { Skin } from '../../Button/constants';
 
 export interface HelperContentDriver extends BaseDriver {
   /** checks if the element exists */
@@ -14,22 +16,29 @@ export interface HelperContentDriver extends BaseDriver {
   getTitleContent: () => string;
   /** Get the text content of the helper's text */
   getBodyContent: () => string;
-  /** Get the text content of the action button */
-  getActionButtonContent: () => string;
+  /** Get the action button test driver */
+  getActionButtonDriver: () => ButtonDriver;
 }
 
-export const helperContentDriverFactory: DriverFactory<HelperContentDriver> = ({element}) => {
+export const helperContentDriverFactory: DriverFactory<
+  HelperContentDriver
+> = factoryParams => {
+  const { element } = factoryParams;
   const title = () => element.querySelector(`[data-hook='${DataHooks.title}']`);
   const body = () => element.querySelector(`[data-hook='${DataHooks.body}']`);
-  const actionButton = () => element.querySelector(`[data-hook='${DataHooks.actionButton}']`);
+  const actionButton = () =>
+    element.querySelector(`[data-hook='${DataHooks.actionButton}']`);
 
   return {
     exists: () => !!element,
     hasTitle: () => !!title(),
     hasBody: () => !!body(),
     hasActionButton: () => !!actionButton(),
+    getActionButtonDriver: () => buttonDriverFactory({
+      ...factoryParams,
+      element: actionButton()
+    }),
     getTitleContent: () => title().textContent,
     getBodyContent: () => body().textContent,
-    getActionButtonContent: () => actionButton().textContent,
   };
 };

--- a/src/components/FloatingHelper/HelperContent/HelperContent.spec.tsx
+++ b/src/components/FloatingHelper/HelperContent/HelperContent.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {helperContentDriverFactory} from './HelperContent.driver';
-import {HelperContent} from '.';
+import {HelperContent,ActionButtonTheme} from '.';
+import { ButtonSkin , ButtonPriority} from '../../Button';
 import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
 
 describe('HelperContent', () => {
@@ -42,8 +43,19 @@ describe('HelperContent', () => {
       const actionText = 'Click Me!'
       const driver = createDriver(<HelperContent actionText={actionText} />);
       expect(driver.hasActionButton()).toBeTruthy();
-      expect(driver.getActionButtonContent()).toBe(actionText);
+      expect(driver.getActionButtonDriver().getTextContent()).toBe(actionText);
+    });
+
+    it('should have white action-button skin by default', () => {
+      const driver = createDriver(<HelperContent actionText="Click me!" />);
+      expect(driver.getActionButtonDriver().getSkin()).toBe(ButtonSkin.white);
+      expect(driver.getActionButtonDriver().getPriority()).toBe(ButtonPriority.secondary);
+    });
+
+    it('should have premium action-button skin', () => {
+      const driver = createDriver(<HelperContent actionText="Click me!" actionTheme={ActionButtonTheme.premium}/>);
+      expect(driver.getActionButtonDriver().getSkin()).toBe(ButtonSkin.premium);
+      expect(driver.getActionButtonDriver().getPriority()).toBe(ButtonPriority.primary);
     });
   });
-
 });

--- a/src/components/FloatingHelper/HelperContent/HelperContent.tsx
+++ b/src/components/FloatingHelper/HelperContent/HelperContent.tsx
@@ -3,45 +3,57 @@ import { string } from 'prop-types';
 import style from './HelperContent.st.css';
 import { Text } from '../../../components/Text';
 import { DataHooks } from './DataHooks';
-import { Button, ButtonSkin, ButtonPriority, ButtonSize } from '../../Button';
+import { Button, ButtonProps, ButtonSkin, ButtonPriority, ButtonSize } from '../../Button';
+import { ActionButtonTheme } from './constants';
+
 export interface HelperContentProps {
   /** Adds text as the title */
   title?: string;
   /** Adds text as the body */
   body?: string;
   /** Sets the text of the action button. Needs to be a non-empty string in order for the action button to appear */
-  actionText?: string
+  actionText?: string;
+  /** Sets the theme of the action button */
+  actionTheme?: ActionButtonTheme;
 }
 
-export const HelperContent: React.SFC<HelperContentProps> = (props: HelperContentProps) => {
+const themeToButtonProps : {[key in ActionButtonTheme]: Pick<ButtonProps, 'skin' | 'priority'>} = {
+  [ActionButtonTheme.white]: {skin: ButtonSkin.white, priority: ButtonPriority.secondary},
+  [ActionButtonTheme.premium]: {skin: ButtonSkin.premium, priority: ButtonPriority.primary}
+}
 
+export const HelperContent: React.SFC<HelperContentProps> = (
+  props: HelperContentProps
+) => {
+  const {title, body, actionText, actionTheme} = props;
   return (
     <div {...style('root', { hasBody: !!props.body }, props)}>
-      {props.title &&
+      {title && (
         <div className={style.title}>
           <Text data-hook={DataHooks.title} bold light>
-            {props.title}
+            {title}
           </Text>
         </div>
-      }
-      {props.body &&
+      )}
+      {body && (
         <div className={style.body}>
           <Text data-hook={DataHooks.body} light>
-            {props.body}
+            {body}
           </Text>
         </div>
-      }
-      {props.actionText && props.actionText.length > 0 &&
-        <Button
-          className={style.action}
-          data-hook={DataHooks.actionButton}
-          skin={ButtonSkin.white}
-          priority={ButtonPriority.secondary}
-          size={ButtonSize.small}
-        >
-          {props.actionText}
-        </Button>
-      }
+      )}
+      {actionText &&
+        actionText.length > 0 && (
+          <Button
+            className={style.action}
+            data-hook={DataHooks.actionButton}
+            skin={themeToButtonProps[actionTheme].skin}
+            priority={themeToButtonProps[actionTheme].priority}
+            size={ButtonSize.small}
+          >
+            {actionText}
+          </Button>
+        )}
     </div>
   );
 };
@@ -50,4 +62,8 @@ HelperContent.propTypes = {
   title: string,
   body: string,
   actionText: string
-}
+};
+
+HelperContent.defaultProps = {
+  actionTheme: ActionButtonTheme.white
+};

--- a/src/components/FloatingHelper/HelperContent/constants.ts
+++ b/src/components/FloatingHelper/HelperContent/constants.ts
@@ -1,0 +1,4 @@
+export enum ActionButtonTheme {
+  white = 'white',
+  premium = 'premium'
+}

--- a/src/components/FloatingHelper/HelperContent/index.ts
+++ b/src/components/FloatingHelper/HelperContent/index.ts
@@ -1,1 +1,2 @@
 export * from './HelperContent';
+export * from './constants'

--- a/stories/HelperContent/HelperContent.story.tsx
+++ b/stories/HelperContent/HelperContent.story.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { HelperContent, HelperContentProps } from '../../src/components/FloatingHelper/HelperContent/HelperContent';
+import { HelperContent, HelperContentProps, ActionButtonTheme } from '../../src/components/FloatingHelper/HelperContent';
 
 import { storySettings } from './StorySettings';
 
@@ -14,7 +14,8 @@ const exampleProps = [
   { title, body },
   { title, body, actionText },
   { title, actionText },
-  { body, actionText }
+  { body, actionText },
+  { title, body, actionText, actionTheme: ActionButtonTheme.premium }
 ];
 
 const examples = exampleProps.map((props, index) => renderExample(storySettings.exampleDataHooks[index], props));

--- a/stories/HelperContent/StorySettings.ts
+++ b/stories/HelperContent/StorySettings.ts
@@ -11,5 +11,6 @@ export const storySettings: StorySettings = {
         'example-title-body-action',
         'example-title-action',
         'example-body-action',
+        'example-title-body-action-premium',
     ]
 };


### PR DESCRIPTION
- according to spec: https://app.zeplin.io/project/5864e02695b5754a69f56150/screen/5a5486c1685f022d22db413c
- HelperContent:ActionButtonTheme = 'white' | 'premium'
  - 'white' (default)=> `ButtonSkin.white` ,`ButtonPriotity.secondary` 
  - 'premium'=> `ButtonSkin.premium`, `ButtonPriority.primary`
