### PR TITLE
<FloatingHelper> - ClosablePopover - add open/close on hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "tslint-react": "^3.5.1",
     "typescript": "^2.6.2",
     "wait-for-cond": "^1.5.1",
+    "wix-eventually": "^2.2.0",
     "wix-storybook-utils": "latest",
     "wix-ui-icons-common": "latest",
     "wix-ui-test-utils": "latest",

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -36,6 +36,56 @@ describe('ClosablePopover', () => {
     });
   });
 
+  describe('onShow/onHide callbacks', () => {
+    it('should call onHide when closed by close-action', () => {
+      let triggerClose;
+      let onHide = jest.fn();
+      const driver = createDriver(createComponent({
+        content: ({ close }) => {
+          triggerClose = close;
+          return <div>the content</div>;
+        },
+        onHide
+      }));
+      triggerClose();
+      
+      expect(onHide).toBeCalled();
+    });
+
+    it('should call onShow when hovered by mouse', () => {
+      let triggerClose;
+      let onShow = jest.fn();
+      const driver = createDriver(createComponent({
+        content: ({ close }) => {
+          triggerClose = close;
+          return <div>the content</div>;
+        },
+        onShow
+      }));
+
+      triggerClose();
+      driver.mouseEnter();
+      expect(onShow).toBeCalled();
+    });
+
+    it('should call onHide when mouse leaves after closed by close-action', () => {
+      let triggerClose;
+      let onHide = jest.fn();
+      const driver = createDriver(createComponent({
+        content: ({ close }) => {
+          triggerClose = close;
+          return <div>the content</div>;
+        },
+        onHide
+      }));
+      
+      triggerClose();
+      driver.mouseEnter();
+      driver.mouseLeave();
+      expect(onHide.mock.calls.length).toBe(2);
+    });
+  });
+
   describe('close', () => {
     it('should be opened by default', () => {
       const driver = createDriver(createComponent());

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
+import * as eventually from 'wix-eventually';
 import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
 import { isTestkitExists } from 'wix-ui-test-utils/vanilla';
 import { isEnzymeTestkitExists } from 'wix-ui-test-utils/enzyme';
@@ -18,7 +19,7 @@ describe('ClosablePopover', () => {
     />
   );
 
-  describe('open/close on hover', () => {
+  describe('open/close on hover', async () => {
     it('should display content on hover and hide it on leave, after closed', async () => {
       let triggerClose;
       const driver = createDriver(createComponent({
@@ -32,13 +33,14 @@ describe('ClosablePopover', () => {
       driver.mouseEnter();
       expect(driver.isContentElementExists()).toBeTruthy();
       driver.mouseLeave();
-      expect(driver.isContentElementExists()).toBeFalsy();
+      await eventually(()=>expect(driver.isContentElementExists()).toBeFalsy());
     });
 
     it('should NOT close on mouse leave when initially opened', async () => {
       const driver = createDriver(createComponent());
       driver.mouseEnter();
       driver.mouseLeave();
+      await new Promise((res,rej)=> setTimeout(res,ClosablePopover.defaultProps.timeout * 2)); // * 2 as arbitrary safety 
       expect(driver.isContentElementExists()).toBeTruthy();
     });
   });
@@ -99,7 +101,7 @@ describe('ClosablePopover', () => {
       expect(driver.isOpened()).toBeTruthy();
     });
 
-    it('should close when closeAction called', () => {
+    it('should close when closeAction called', async () => {
       let triggerClose;
       const driver = createDriver(createComponent({
         content: ({ close }) => {
@@ -109,7 +111,7 @@ describe('ClosablePopover', () => {
       }));
       expect(driver.isOpened()).toBeTruthy();
       triggerClose();
-      expect(driver.isOpened()).toBeFalsy();
+      await eventually(()=> expect(driver.isOpened()).toBeFalsy());
     });
   });
 

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -3,7 +3,6 @@ import { mount } from 'enzyme';
 import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
 import { isTestkitExists } from 'wix-ui-test-utils/vanilla';
 import { isEnzymeTestkitExists } from 'wix-ui-test-utils/enzyme';
-
 import { closablePopoverDriverFactory, ClosablePopoverDriver } from './ClosablePopover.driver';
 import { ClosablePopover, ClosablePopoverProps } from './ClosablePopover';
 import defaults = require('lodash/defaults');
@@ -18,7 +17,25 @@ describe('ClosablePopover', () => {
       {...partialProps}
     />
   );
-  
+
+  describe('open/close on hover', () => {
+    it('should display content on hover and hide it on leave, after closed', async () => {
+      let triggerClose;
+      const driver = createDriver(createComponent({
+        content: ({ close }) => {
+          triggerClose = close;
+          return <div>the content</div>;
+        }
+      }));
+      triggerClose();
+
+      driver.mouseEnter();
+      expect(driver.isContentElementExists()).toBeTruthy();
+      driver.mouseLeave();
+      expect(driver.isContentElementExists()).toBeFalsy();
+    });
+  });
+
   describe('close', () => {
     it('should be opened by default', () => {
       const driver = createDriver(createComponent());

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -36,67 +36,60 @@ describe('ClosablePopover', () => {
     });
 
     it('should NOT close on mouse leave when initially opened', async () => {
-      let triggerClose;
-      const driver = createDriver(createComponent({
-        content: ({ close }) => {
-          triggerClose = close;
-          return <div>the content</div>;
-        }
-      }));
-
+      const driver = createDriver(createComponent());
       driver.mouseEnter();
       driver.mouseLeave();
       expect(driver.isContentElementExists()).toBeTruthy();
     });
   });
 
-  describe('onShow/onHide callbacks', () => {
-    it('should call onHide when closed by close-action', () => {
+  describe('onOpened/onClosed callbacks', () => {
+    it('should call onClosed when closed by close-action', () => {
       let triggerClose;
-      let onHide = jest.fn();
+      let onClosed = jest.fn();
       const driver = createDriver(createComponent({
         content: ({ close }) => {
           triggerClose = close;
           return <div>the content</div>;
         },
-        onHide
+        onClosed
       }));
       triggerClose();
       
-      expect(onHide).toBeCalled();
+      expect(onClosed).toBeCalled();
     });
 
-    it('should call onShow when hovered by mouse', () => {
+    it('should call onOpened when hovered by mouse', () => {
       let triggerClose;
-      let onShow = jest.fn();
+      let onOpened = jest.fn();
       const driver = createDriver(createComponent({
         content: ({ close }) => {
           triggerClose = close;
           return <div>the content</div>;
         },
-        onShow
+        onOpened
       }));
 
       triggerClose();
       driver.mouseEnter();
-      expect(onShow).toBeCalled();
+      expect(onOpened).toBeCalled();
     });
 
-    it('should call onHide when mouse leaves after closed by close-action', () => {
+    it('should call onClosed when mouse leaves after closed by close-action', () => {
       let triggerClose;
-      let onHide = jest.fn();
+      let onClosed = jest.fn();
       const driver = createDriver(createComponent({
         content: ({ close }) => {
           triggerClose = close;
           return <div>the content</div>;
         },
-        onHide
+        onClosed
       }));
       
       triggerClose();
       driver.mouseEnter();
       driver.mouseLeave();
-      expect(onHide.mock.calls.length).toBe(2);
+      expect(onClosed.mock.calls.length).toBe(2);
     });
   });
 

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -48,50 +48,50 @@ describe('ClosablePopover', () => {
   describe('onOpened/onClosed callbacks', () => {
     it('should call onClosed when closed by close-action', () => {
       let triggerClose;
-      let onClosed = jest.fn();
+      let onClose = jest.fn();
       const driver = createDriver(createComponent({
         content: ({ close }) => {
           triggerClose = close;
           return <div>the content</div>;
         },
-        onClosed
+        onClose
       }));
       triggerClose();
       
-      expect(onClosed).toBeCalled();
+      expect(onClose).toBeCalled();
     });
 
     it('should call onOpened when hovered by mouse', () => {
       let triggerClose;
-      let onOpened = jest.fn();
+      let onOpen = jest.fn();
       const driver = createDriver(createComponent({
         content: ({ close }) => {
           triggerClose = close;
           return <div>the content</div>;
         },
-        onOpened
+        onOpen
       }));
 
       triggerClose();
       driver.mouseEnter();
-      expect(onOpened).toBeCalled();
+      expect(onOpen).toBeCalled();
     });
 
     it('should call onClosed when mouse leaves after closed by close-action', () => {
       let triggerClose;
-      let onClosed = jest.fn();
+      let onClose = jest.fn();
       const driver = createDriver(createComponent({
         content: ({ close }) => {
           triggerClose = close;
           return <div>the content</div>;
         },
-        onClosed
+        onClose
       }));
       
       triggerClose();
       driver.mouseEnter();
       driver.mouseLeave();
-      expect(onClosed.mock.calls.length).toBe(2);
+      expect(onClose.mock.calls.length).toBe(2);
     });
   });
 

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -17,7 +17,8 @@ describe('ClosablePopover', () => {
       placement="right"
       {...partialProps}
     />
-  )
+  );
+  
   describe('close', () => {
     it('should be opened by default', () => {
       const driver = createDriver(createComponent());

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.spec.tsx
@@ -34,6 +34,20 @@ describe('ClosablePopover', () => {
       driver.mouseLeave();
       expect(driver.isContentElementExists()).toBeFalsy();
     });
+
+    it('should NOT close on mouse leave when initially opened', async () => {
+      let triggerClose;
+      const driver = createDriver(createComponent({
+        content: ({ close }) => {
+          triggerClose = close;
+          return <div>the content</div>;
+        }
+      }));
+
+      driver.mouseEnter();
+      driver.mouseLeave();
+      expect(driver.isContentElementExists()).toBeTruthy();
+    });
   });
 
   describe('onShow/onHide callbacks', () => {

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -42,7 +42,7 @@ export type ClosablePopoverProps = PickedPopoverProps & ClosablePopoverOwnProps;
  * calling a closeAction.
  */
 export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, ClosablePopoverState> {
-  state: ClosablePopoverState;
+  state: ClosablePopoverState = { opened: true, wasClosed: false};
 
   static propTypes: React.ValidationMap<ClosablePopoverProps> = {
     ...pickedPopoverPropTypes,
@@ -55,12 +55,6 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
 
   static defaultProps: Partial<ClosablePopoverProps> = {
     timeout: 150
-  }
-
-  constructor(props: ClosablePopoverProps) {
-    super(props);
-
-    this.state = { opened: true, wasClosed: false};
   }
 
   isControlled() {

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -22,7 +22,7 @@ export interface ClosablePopoverOwnProps {
   target: React.ReactNode;
   /** callback to call when the popover content was opened */
   onOpened?: Function;
-  /** callback to call when the popover content was closed */
+  /** callback to call when the popover content was closed. NOTE: this callback is called when the close timeout (if exists) starts */
   onClosed?: Function;
 }
 

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -53,27 +53,25 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     onHide: func,
   };
 
+
   constructor(props: ClosablePopoverProps) {
     super(props);
 
-    this.open = this.open.bind(this);
-    this.close = this.close.bind(this);
-
-    this.state = { opened: true };
+    this.state = { opened: true};
   }
 
-  get isControlled() {
+  isControlled() {
     return isBoolean(this.props.opened);
   }
 
-  open() {
+  open = () => {
     if (!this.state.opened) {
       this.setState({opened: true},  ()=>{this.props.onShow && this.props.onShow()});
     }
   }
 
-  close() {
-    if (this.isControlled) {
+  close = () => {
+    if (this.isControlled()) {
       throw new Error('ClosablePopover.close() can not be called when component is Controlled. (opened prop should be undefined)');
     }
     this.state.opened && this.setState({ opened: false }, ()=>{this.props.onHide && this.props.onHide()});
@@ -84,10 +82,11 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     // Stylabel (and the data-hook also). Also some variable constants are destructed from props
     // only to be 'omit' and are not in use. (Using lodash.omit is not type safe)
     const { opened, content, target, children, onHide, onShow, ...rest } = this.props;
-    const open = this.isControlled ? this.props.opened : this.state.opened;
+    const open = this.isControlled() ? this.props.opened : this.state.opened;
+    const popoverProps: PopoverProps = {...rest, shown: open, onMouseEnter: this.open, onMouseLeave: this.close};
 
     // Using createElement() in order to get ts props validation.
-    return React.createElement(Popover, { shown: open, ...rest }, (
+    return React.createElement(Popover, popoverProps, (
       <Popover.Element>
         {target}
       </Popover.Element>

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -20,11 +20,10 @@ export interface ClosablePopoverOwnProps {
   content: (closable: ClosablePopoverActions) => React.ReactNode;
   /** The popover's target element*/
   target: React.ReactNode;
-  /** callback to call when the tooltip is shown */
-  onShow?: Function;
-  /** callback to call when the tooltip is being hidden */
-  onHide?: Function;
-  
+  /** callback to call when the popover content was opened */
+  onOpened?: Function;
+  /** callback to call when the popover content was closed */
+  onClosed?: Function;
 }
 
 export interface ClosablePopoverState {
@@ -50,8 +49,8 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     opened: bool,
     content: func,
     target: node,
-    onShow: func,
-    onHide: func,
+    onOpened: func,
+    onClosed: func,
   };
 
 
@@ -70,7 +69,7 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
       throw new Error('ClosablePopover.open() can not be called when component is Controlled. (opened prop should be undefined)');
     }
     if (!this.state.opened) {
-      this.setState({opened: true},  ()=>{this.props.onShow && this.props.onShow()});
+      this.setState({opened: true},  ()=>{this.props.onOpened && this.props.onOpened()});
     }
   }
 
@@ -78,7 +77,7 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     if (this.isControlled()) {
       throw new Error('ClosablePopover.close() can not be called when component is Controlled. (opened prop should be undefined)');
     }
-    this.state.opened && this.setState({ opened: false, wasClosed: true }, ()=>{this.props.onHide && this.props.onHide()});
+    this.state.opened && this.setState({ opened: false, wasClosed: true }, ()=>{this.props.onClosed && this.props.onClosed()});
   }
 
   handleMouseLeave = () => {
@@ -91,7 +90,7 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     // NOTE: we can not use pick, since there are unknown 'data-*' props coming from 
     // Stylabel (and the data-hook also). Also some variable constants are destructed from props
     // only to be 'omit' and are not in use. (Using lodash.omit is not type safe)
-    const { opened, content, target, children, onHide, onShow, ...rest } = this.props;
+    const { opened, content, target, children, onClosed, onOpened, ...rest } = this.props;
     const open = this.isControlled() ? this.props.opened : this.state.opened;
     const popoverProps: PopoverProps = {...rest, shown: open, onMouseEnter: this.open, onMouseLeave: this.handleMouseLeave};
 

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -42,7 +42,7 @@ export type ClosablePopoverProps = PickedPopoverProps & ClosablePopoverOwnProps;
  * calling a closeAction.
  */
 export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, ClosablePopoverState> {
-  state: ClosablePopoverState = { opened: true, wasClosed: false};
+  state: ClosablePopoverState = { opened: true, wasClosed: false };
 
   static propTypes: React.ValidationMap<ClosablePopoverProps> = {
     ...pickedPopoverPropTypes,
@@ -66,7 +66,7 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
       throw new Error('ClosablePopover.open() can not be called when component is Controlled. (opened prop should be undefined)');
     }
     if (!this.state.opened) {
-      this.setState({opened: true},  ()=>{this.props.onOpened && this.props.onOpened()});
+      this.setState({ opened: true }, () => { this.props.onOpened && this.props.onOpened() });
     }
   }
 
@@ -74,7 +74,7 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     if (this.isControlled()) {
       throw new Error('ClosablePopover.close() can not be called when component is Controlled. (opened prop should be undefined)');
     }
-    this.state.opened && this.setState({ opened: false, wasClosed: true }, ()=>{this.props.onClosed && this.props.onClosed()});
+    this.state.opened && this.setState({ opened: false, wasClosed: true }, () => { this.props.onClosed && this.props.onClosed() });
   }
 
   handleMouseLeave = () => {
@@ -84,23 +84,27 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
   }
 
   render() {
-    // NOTE: we can not use pick, since there are unknown 'data-*' props coming from 
-    // Stylabel (and the data-hook also). Also some variable constants are destructed from props
-    // only to be 'omit' and are not in use. (Using lodash.omit is not type safe)
     const { opened, content, target, children, onClosed, onOpened, ...rest } = this.props;
     const open = this.isControlled() ? this.props.opened : this.state.opened;
-    const popoverProps: PopoverProps = {...rest, shown: open, onMouseEnter: this.open, onMouseLeave: this.handleMouseLeave};
+    
+    const popoverProps: PopoverProps = {
+      ...rest,
+      shown: open,
+      onMouseEnter: this.open,
+      onMouseLeave: this.handleMouseLeave
+    };
 
-    // Using createElement() in order to get ts props validation.
-    return React.createElement(Popover, popoverProps, (
-      <Popover.Element>
-        {target}
-      </Popover.Element>
-    ), (
+    return (
+      <Popover
+        {...popoverProps}
+      >
+        <Popover.Element>
+          {target}
+        </Popover.Element>
         <Popover.Content>
           {content(this.actions)}
         </Popover.Content>
-      )
+      </Popover>
     );
   }
 

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -21,9 +21,9 @@ export interface ClosablePopoverOwnProps {
   /** The popover's target element*/
   target: React.ReactNode;
   /** callback to call when the popover content was opened */
-  onOpened?: Function;
+  onOpen?: Function;
   /** callback to call when the popover content was closed. NOTE: this callback is called when the close timeout (if exists) starts */
-  onClosed?: Function;
+  onClose?: Function;
 }
 
 export interface ClosablePopoverState {
@@ -49,8 +49,8 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     opened: bool,
     content: func,
     target: node,
-    onOpened: func,
-    onClosed: func,
+    onOpen: func,
+    onClose: func,
   };
 
   static defaultProps: Partial<ClosablePopoverProps> = {
@@ -66,7 +66,7 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
       throw new Error('ClosablePopover.open() can not be called when component is Controlled. (opened prop should be undefined)');
     }
     if (!this.state.opened) {
-      this.setState({ opened: true }, () => { this.props.onOpened && this.props.onOpened() });
+      this.setState({ opened: true }, () => { this.props.onOpen && this.props.onOpen() });
     }
   }
 
@@ -74,7 +74,7 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     if (this.isControlled()) {
       throw new Error('ClosablePopover.close() can not be called when component is Controlled. (opened prop should be undefined)');
     }
-    this.state.opened && this.setState({ opened: false, wasClosed: true }, () => { this.props.onClosed && this.props.onClosed() });
+    this.state.opened && this.setState({ opened: false, wasClosed: true }, () => { this.props.onClose && this.props.onClose() });
   }
 
   handleMouseLeave = () => {
@@ -84,9 +84,9 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
   }
 
   render() {
-    const { opened, content, target, children, onClosed, onOpened, ...rest } = this.props;
+    const { opened, content, target, children, onClose, onOpen, ...rest } = this.props;
     const open = this.isControlled() ? this.props.opened : this.state.opened;
-    
+
     const popoverProps: PopoverProps = {
       ...rest,
       shown: open,

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -27,7 +27,7 @@ export interface ClosablePopoverOwnProps {
 }
 
 export interface ClosablePopoverState {
-  opened?: boolean;
+  open?: boolean;
   wasClosed: boolean;
 }
 
@@ -42,7 +42,7 @@ export type ClosablePopoverProps = PickedPopoverProps & ClosablePopoverOwnProps;
  * calling a closeAction.
  */
 export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, ClosablePopoverState> {
-  state: ClosablePopoverState = { opened: true, wasClosed: false };
+  state: ClosablePopoverState = { open: true, wasClosed: false };
 
   static propTypes: React.ValidationMap<ClosablePopoverProps> = {
     ...pickedPopoverPropTypes,
@@ -65,8 +65,8 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     if (this.isControlled()) {
       throw new Error('ClosablePopover.open() can not be called when component is Controlled. (opened prop should be undefined)');
     }
-    if (!this.state.opened) {
-      this.setState({ opened: true }, () => { this.props.onOpen && this.props.onOpen() });
+    if (!this.state.open) {
+      this.setState({ open: true }, () => { this.props.onOpen && this.props.onOpen() });
     }
   }
 
@@ -74,7 +74,7 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     if (this.isControlled()) {
       throw new Error('ClosablePopover.close() can not be called when component is Controlled. (opened prop should be undefined)');
     }
-    this.state.opened && this.setState({ opened: false, wasClosed: true }, () => { this.props.onClose && this.props.onClose() });
+    this.state.open && this.setState({ open: false, wasClosed: true }, () => { this.props.onClose && this.props.onClose() });
   }
 
   handleMouseLeave = () => {
@@ -85,7 +85,7 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
 
   render() {
     const { opened, content, target, children, onClose, onOpen, ...rest } = this.props;
-    const open = this.isControlled() ? this.props.opened : this.state.opened;
+    const open = this.isControlled() ? this.props.opened : this.state.open;
 
     const popoverProps: PopoverProps = {
       ...rest,

--- a/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
+++ b/src/components/FloatingHelper/ClosablePopover/ClosablePopover.tsx
@@ -53,6 +53,9 @@ export class ClosablePopover extends React.PureComponent<ClosablePopoverProps, C
     onClosed: func,
   };
 
+  static defaultProps: Partial<ClosablePopoverProps> = {
+    timeout: 150
+  }
 
   constructor(props: ClosablePopoverProps) {
     super(props);

--- a/src/components/FloatingHelper/FloatingHelper.spec.tsx
+++ b/src/components/FloatingHelper/FloatingHelper.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
+import * as eventually from 'wix-eventually';
 import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
 import { isTestkitExists } from 'wix-ui-test-utils/vanilla';
 import { isEnzymeTestkitExists } from 'wix-ui-test-utils/enzyme';
@@ -85,10 +86,10 @@ describe('FloatingHelper', () => {
       expect(driver.isOpened()).toBeTruthy();
     });
 
-    it('should close popover when close-button is clicked', () => {
+    it('should close popover when close-button is clicked',async () => {
       const driver = createEnzymeDriver(buildComponent());
       driver.clickCloseButton();
-      expect(driver.isOpened()).toBeFalsy();
+      await eventually(()=>expect(driver.isOpened()).toBeFalsy());
     });
   });
 


### PR DESCRIPTION
According to spec, the Floating
Helper should be initially opened, and after closed by close button, 
it should behave as a tooltip in the sense that is opened on mouse enter and closes on mouse leave.

We might need to add the ability to have it initially closed, and then open it programatically (putting it into that onTimeClickToClose mode)