### PR TITLE
docs(*): fix Autocomplete, LabelWithOptions & Thumbnail stories

### DIFF
--- a/stories/Autocomplete.story.tsx
+++ b/stories/Autocomplete.story.tsx
@@ -3,6 +3,8 @@ import {Autocomplete} from '../src/components/Autocomplete';
 import {generateOptions} from 'wix-ui-core/dist/src/baseComponents/DropdownOption/OptionsExample';
 import {Option, DividerArgs} from 'wix-ui-core/dist/src/baseComponents/DropdownOption';
 
+const options = generateOptions((args: Partial<DividerArgs> = {}) => Autocomplete.createDivider(args.value));
+
 export default {
   category: 'Components',
   storyName: 'Autocomplete',
@@ -11,18 +13,28 @@ export default {
 
   componentProps: {
     'data-hook': 'storybook-autocomplete',
-    options: generateOptions((args: Partial<DividerArgs> = {}) => Autocomplete.createDivider(args.value))
+    options,
+    fixedFooter: 'Fixed Footer',
+    fixedHeader: 'Fixed Header',
   },
 
   exampleProps: {
-    fixedFooter: [null, <div key="1">Fixed Footer</div>],
-    fixedHeader: [null, <div key="2">Fixed Header</div>],
     onSelect: (option: Option) => option.value,
-    initialSelectedId: [null, 1],
     onManualInput: (value: string) => `Manual input: ${value}`,
     onBlur: () => 'Triggered onBlur',
     onFocus: () => 'Triggered onFocus',
     onChange: evt => evt.target.value,
-    size: ['small', 'medium', 'large']
+    size: ['small', 'medium', 'large'],
+
+    options: [
+      { value: options.slice(0, 1), label: '1 example option' },
+      { value: options.slice(0, 5), label: '5 example options' },
+      { value: options, label: '20 example options' }
+    ],
+
+    initialSelectedId: [
+      { value: [1], label: '[1]' },
+      { value: [1, 2, 3], label: '[1, 2, 3]' }
+    ]
   }
 };

--- a/stories/LabelWithOptions.story.tsx
+++ b/stories/LabelWithOptions.story.tsx
@@ -12,16 +12,15 @@ export default {
   componentProps: {
     'data-hook': 'storybook-labelwithoptions',
     options: generateOptions((args: Partial<DividerArgs> = {}) => LabelWithOptions.createDivider(args.value)),
-    placeholder: 'With placeholder'
+    placeholder: 'With placeholder',
+    fixedFooter: 'Fixed Footer',
+    fixedHeader: 'Fixed Header',
+    initialSelectedIds: [1]
   },
 
   exampleProps: {
-    fixedFooter: [null, <div key="1">Fixed Footer</div>],
-    fixedHeader: [null, <div key="2">Fixed Header</div>],
     onSelect: (option: Option) => option.value,
     onDeselect: (option: Option) => option.value,
-    initialSelectedIds: [null, [1]],
-    placeholder: ['With placeholder', null],
     size: ['small', 'medium', 'large']
   }
 };

--- a/stories/LabelWithOptions.story.tsx
+++ b/stories/LabelWithOptions.story.tsx
@@ -1,7 +1,8 @@
-import * as React from 'react';
 import {LabelWithOptions} from '../src/components/LabelWithOptions';
 import {generateOptions} from 'wix-ui-core/dist/src/baseComponents/DropdownOption/OptionsExample';
 import {Option, DividerArgs} from 'wix-ui-core/dist/src/baseComponents/DropdownOption';
+
+const options = generateOptions((args: Partial<DividerArgs> = {}) => LabelWithOptions.createDivider(args.value));
 
 export default {
   category: 'Components',
@@ -11,16 +12,21 @@ export default {
 
   componentProps: {
     'data-hook': 'storybook-labelwithoptions',
-    options: generateOptions((args: Partial<DividerArgs> = {}) => LabelWithOptions.createDivider(args.value)),
+    options,
     placeholder: 'With placeholder',
     fixedFooter: 'Fixed Footer',
-    fixedHeader: 'Fixed Header',
-    initialSelectedIds: [1]
+    fixedHeader: 'Fixed Header'
   },
 
   exampleProps: {
     onSelect: (option: Option) => option.value,
     onDeselect: (option: Option) => option.value,
-    size: ['small', 'medium', 'large']
+    size: ['small', 'medium', 'large'],
+
+    options: [
+      { value: options.slice(0, 1), label: '1 example option' },
+      { value: options.slice(0, 5), label: '5 example options' },
+      { value: options, label: '20 example options' }
+    ]
   }
 };

--- a/stories/Thumbnail.story.tsx
+++ b/stories/Thumbnail.story.tsx
@@ -1,18 +1,29 @@
 import * as React from 'react';
-import {Thumbnail} from '../src/components/Thumbnail';
-import * as ThumbnailSource from '!raw-loader!../src/components/Thumbnail/Thumbnail.tsx';
+
 import Image from 'wix-ui-icons-common/Image';
+
+import {Thumbnail} from '../src/components/Thumbnail';
+
+const image = <Image width="240" height="180"/>;
 
 export default {
   category: 'Components',
   storyName: 'Thumbnail',
   component: Thumbnail,
-  source: ThumbnailSource,
   componentPath: '../src/components/Thumbnail/Thumbnail.tsx',
+
   componentProps: {
     'data-hook': 'storybook-thumbnail',
     title: 'Thumnbail Title',
     description: 'Description about this thumbnail option goes here',
-    image: <Image width="240" height="180"/>
+    image
+  },
+
+  exampleProps: {
+    image: [
+      { label: 'small image', value: <Image width="64" height="64"/> },
+      { label: 'normal image', value: image },
+      { label: 'big image', value: <Image width="400" height="400"/> }
+    ]
   }
 };


### PR DESCRIPTION
fixing red screen of death and also start to use `{ label, value }` shape of object which `exampleProps` now supports