### PR TITLE
chore(package): publish src folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "dist",
+    "src",
     "*.js",
     "*.d.ts",
     "!wallaby.js",


### PR DESCRIPTION
required for by autodocs

without this wix-style-react 4.0.0 has a broken `Label` story