### PR TITLE
Bump ui core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ts-jest": "^22.0.3",
     "tslint-config-prettier": "^1.12.0",
     "tslint-react": "^3.5.1",
-    "typescript": "^2.6.2",
+    "typescript": "~2.8.3",
     "wait-for-cond": "^1.5.1",
     "wix-eventually": "^2.2.0",
     "wix-storybook-utils": "^1.0.85",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.5",
-    "wix-ui-core": "1.0.457",
+    "wix-ui-core": "1.0.466",
     "wix-ui-theme": "1.0.43",
     "wix-ui-icons-common": "1.0.36"
   },


### PR DESCRIPTION
In order to include Popover fix.

Also restrict typescript version to ~2.8.3 like we do now in wix-ui