### PR TITLE
(fix)<Button> - fix hover text color for white-secondary

### DIFF
--- a/src/components/Button/Button.st.css
+++ b/src/components/Button/Button.st.css
@@ -4,8 +4,14 @@
 }
 
 :import {
+  -st-from: "../Text/Text.st.css";
+  -st-default: Text;
+}
+
+:import {
   -st-from: "../../palette.st.css";
-  -st-named: main, backgroundSecondary, danger, premium, mainHover, mainMutedBackground, premiumHover, dangerHover;
+  -st-named: main, backgroundSecondary, danger, premium, mainHover, mainMutedBackground, premiumHover, dangerHover,
+    buttonSecondaryText;
 }
 
 .root {
@@ -23,6 +29,9 @@
   cursor: pointer;
 }
 
+.text {
+  -st-extends: Text;
+}
 /*skins ans priority*/
 
 :vars {
@@ -54,6 +63,10 @@
 .root:skin(white):priority(secondary) {
   background-color: transparent;
   border-color: value(skinWhiteColor);
+}
+
+.root:skin(white):priority(secondary):hover .text{
+  color: value(buttonSecondaryText)
 }
 
 .root:skin(destructive):priority(primary) {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -47,6 +47,7 @@ export const Button: React.SFC<ButtonProps> = props => {
         light={textColorProps.light}
         skin={textColorProps.skin}
         size={textSize}
+        {...style('text')}
       >
         {children}
       </Text>

--- a/src/palette.st.css
+++ b/src/palette.st.css
@@ -76,6 +76,8 @@
   disabledText: value(D50);
   primaryLightText: value(WHITE);
   secondaryLightText: value(D50);
+
+  buttonSecondaryText: value(B10);
   
   linkedText: value(brandPrimary);
   linkedTextHover: value(brandPrimary);

--- a/stories/Button/Button.story.tsx
+++ b/stories/Button/Button.story.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Button, ButtonProps, ButtonSkin as Skin, ButtonPriority as Priority, ButtonSize as Size } from '../../src/components/Button';
 import * as ButtonSource from '!raw-loader!../../src/components/Button/Button.tsx';
 import { storySettings } from './storySettings';
+import {enumValues} from '../../src/utils';
 
 function PButton(props: ButtonProps) {
   return (
@@ -24,7 +25,9 @@ export default {
     children: ['Click me!'],
   }),
   exampleProps: {
-    skin: ['standard', 'white']
+    skin: enumValues(Skin),
+    priority: enumValues(Priority),
+    size: enumValues(Size)
   },
   examples: (
     <div style={{backgroundColor: '#f6f8fa', margin: '10px', padding: '16px'}}>


### PR DESCRIPTION
A quick hack fixing the hover text color only for skin:white, priority:secondary,
which is needed for FloatingHelper. 