### PR TITLE
`<FloatingHelper/>` - Add `light` appearance

### DIFF
--- a/src/components/Button/Button.st.css
+++ b/src/components/Button/Button.st.css
@@ -14,6 +14,11 @@
     buttonSecondaryText;
 }
 
+:import {
+  -st-from: "../../colors.st.css";
+  -st-named: B10, WHITE;
+}
+
 .root {
   -st-extends: Button;
   -st-states: skin(enum(standard, white, destructive, premium)), priority(enum(primary, secondary)), size(enum(large, medium, small, tiny));
@@ -53,6 +58,14 @@
 .root:skin(standard):priority(secondary) {
   background-color: transparent;
   border-color: value(skinStandardColor);
+}
+
+.root:skin(standard):priority(secondary) .text{
+  color: value(B10);
+}
+
+.root:skin(standard):priority(secondary):hover .text{
+  color: value(WHITE);
 }
 
 .root:skin(white):priority(primary) {

--- a/src/components/CloseButton/CloseButton.e2e.ts
+++ b/src/components/CloseButton/CloseButton.e2e.ts
@@ -1,19 +1,23 @@
 import * as eyes from 'eyes.it';
 import { browser } from 'protractor';
 import { waitForVisibilityOf, createStoryUrl } from 'wix-ui-test-utils/protractor';
+import { enumValues } from '../../utils';
 import { closeButtonTestkitFactory } from '../../testkit/protractor';
 import { storySettings } from '../../../stories/CloseButton/storySettings';
+import {Skin, Size} from './constants';
 
 describe('CloseButton', () => {
   const storyUrl = createStoryUrl(storySettings);
   const dataHook = 'storybook-close-button';
 
-  beforeEach(() => browser.get(storyUrl));
+  beforeAll(() => browser.get(storyUrl));
 
-  eyes.it('should render with default props', async () => {
+  eyes.it('should render all skins', async () => {
     const driver = closeButtonTestkitFactory({ dataHook });
     await waitForVisibilityOf(driver.element());
-    expect(await driver.element().isPresent()).toBeTruthy();
+    for (let skin in enumValues(Skin)) {
+      eyes.checkWindow(`skin=${skin}`);
+    }
   });
 
 });

--- a/src/components/CloseButton/CloseButton.e2e.ts
+++ b/src/components/CloseButton/CloseButton.e2e.ts
@@ -16,7 +16,7 @@ describe('CloseButton', () => {
     const driver = closeButtonTestkitFactory({ dataHook });
     await waitForVisibilityOf(driver.element());
     for (let skin in enumValues(Skin)) {
-      eyes.checkWindow(`skin=${skin}`);
+      await eyes.checkWindow(`skin=${skin}`);
     }
   });
 

--- a/src/components/CloseButton/CloseButton.st.css
+++ b/src/components/CloseButton/CloseButton.st.css
@@ -7,9 +7,14 @@
   -st-from: "../../palette.st.css";
   -st-named: main, mainHover, mainMutedBackground, WHITE;
 }
+
+:import {
+  -st-from: "../../colors.st.css";
+  -st-named: D10, D20;
+}
 .root {
   -st-extends: Button;
-  -st-states: skin(enum(standard, white)), size(enum(small, large));
+  -st-states: skin(enum(standard, white, dark)), size(enum(small, large));
 
   box-sizing: border-box;
   
@@ -36,6 +41,13 @@
 }
 .root:skin(white):hover {
   color: value(mainMutedBackground);
+}
+
+.root:skin(dark) {
+  color: value(D10);
+}
+.root:skin(dark):hover {
+  color: value(D20);
 }
 
 .root:size(small) {

--- a/src/components/CloseButton/constants.ts
+++ b/src/components/CloseButton/constants.ts
@@ -1,6 +1,7 @@
 export enum Skin {
   standard = 'standard',
-  white = 'white'
+  white = 'white',
+  dark = 'dark'
 };
 
 export enum Size {

--- a/src/components/FloatingHelper/FloatingHelper.e2e.ts
+++ b/src/components/FloatingHelper/FloatingHelper.e2e.ts
@@ -1,25 +1,26 @@
 import * as eyes from 'eyes.it';
-import { browser, ElementFinder } from 'protractor';
+import { browser, ElementFinder , $} from 'protractor';
 import { createStoryUrl, waitForVisibilityOf, scrollToElement } from 'wix-ui-test-utils/protractor';
 import autoExampleDriver = require('wix-storybook-utils/AutoExampleDriver');
 import { floatingHelperTestkitFactory, FloatingHelperDriver } from '../../testkit/protractor';
 import { storySettings } from '../../../stories/FloatingHelper/StorySettings';
 
 describe('FloatingHelper', () => {
-    const storyUrl = createStoryUrl({kind:storySettings.kind, story:storySettings.story, withExamples:false});
     let driver: FloatingHelperDriver;
-
-    beforeAll(async () => {
+    
+    eyes.it('should be opened by default', async () => {
+        const storyUrl = createStoryUrl({kind:storySettings.kind, story:storySettings.story, withExamples:false});
         await browser.get(storyUrl);
         driver = floatingHelperTestkitFactory({ dataHook: storySettings.dataHook });
         await waitForVisibilityOf(driver.element(), 'Cannot find FloatingHelper');
+        expect(await driver.isOpened()).toBeTruthy();
     });
 
-    afterEach(() => autoExampleDriver.reset());
-
-    describe('default', () => {
-        eyes.it('should be opened by default', async () => {
-            expect(await driver.isOpened()).toBeTruthy();
-        });
+    eyes.it('should have appearance light', async () => {
+        const storyUrl = createStoryUrl({kind:storySettings.kind, story:storySettings.story, withExamples:true});
+        await browser.get(storyUrl);
+        driver = floatingHelperTestkitFactory({ dataHook: 'story-floating-helper-light' });
+        await waitForVisibilityOf(driver.element(), 'Cannot find FloatingHelper');
+        await scrollToElement($('[data-hook=appearance-light-example-container]'));
     });
 });

--- a/src/components/FloatingHelper/FloatingHelper.st.css
+++ b/src/components/FloatingHelper/FloatingHelper.st.css
@@ -4,6 +4,21 @@
 }
 
 :import {
+  -st-from: "./FloatingHelperContent/FloatingHelperContent.st.css";
+  -st-default: FloatingHelperContent;
+}
+
+:import {
+  -st-from: "../Text/Text.st.css";
+  -st-default: Text;
+}
+
+:import {
+  -st-from: "../Button/Button.st.css";
+  -st-default: Button;
+}
+
+:import {
   -st-from: "../../palette.st.css";
   -st-named: brandSecondary, backgroundSecondary;
 }
@@ -22,16 +37,30 @@
   /* TODO: create and use a fade function */
 
   /** background color D10 with opacity 0.95 */
-  backgroundColor: rgba(22,45,61,0.95);
+  backgroundColorDark: rgba(22,45,61,0.95);
+  backgroundColorLight: WHITE;
   closeButtonPadding: 6px;
 }
 
 .root {
-  -st-states: bounce, placement-right, placement-left, placement-top, placement-bottom;
+  -st-states: bounce, placement-right, placement-left, placement-top, placement-bottom, appearance(enum(dark,light));
   -st-extends: Popover;
+}
+
+.root:appearance(dark) {
   -st-mixin: Popover(
-    contentBorderColor value(backgroundColor),
-    contentBackgroundColor value(backgroundColor),
+    contentBorderColor value(backgroundColorDark),
+    contentBackgroundColor value(backgroundColorDark),
+    contentBorderWidth 0,
+    contentBorderRadius 8px,
+    contentPadding 0 0
+    );
+}
+
+.root:appearance(light) {
+  -st-mixin: Popover(
+    contentBorderColor value(backgroundColorLight),
+    contentBackgroundColor value(backgroundColorLight),
     contentBorderWidth 0,
     contentBorderRadius 8px,
     contentPadding 0 0

--- a/src/components/FloatingHelper/FloatingHelper.st.css
+++ b/src/components/FloatingHelper/FloatingHelper.st.css
@@ -1,6 +1,7 @@
 :import {
-  -st-from: "wix-ui-core/index.st.css";
-  -st-named: Popover;
+  -st-from: "wix-ui-core/dist/src/components/Popover/Popover.st.css";
+  -st-default: Popover;
+  -st-named: withArrow, arrow;
 }
 
 :import {
@@ -25,12 +26,12 @@
 
 :import {
   -st-from: "../../colors.st.css";
-  -st-named: WHITE;
+  -st-named: D80;
 }
 
 :import {
   -st-from: "../../shadows.st.css";
-  -st-named: shadow40;
+  -st-named: shadow30;
 }
 
 :vars {
@@ -38,7 +39,7 @@
 
   /** background color D10 with opacity 0.95 */
   backgroundColorDark: rgba(22,45,61,0.95);
-  backgroundColorLight: WHITE;
+  backgroundColorLight: value(D80);
   closeButtonPadding: 6px;
 }
 
@@ -67,13 +68,17 @@
     );
 }
 
+.root::popover.withArrow .arrow {
+  z-index: 2;
+}
+
 /* popoverContent and innerContent are taken from Tooltip.tooltipContent,
  * but I split them.
 */
 .root::popoverContent {
   position: relative;
   box-sizing: border-box;
-  box-shadow: value(shadow40);
+  box-shadow: value(shadow30);
 }
 
 .closeButton {

--- a/src/components/FloatingHelper/FloatingHelper.tsx
+++ b/src/components/FloatingHelper/FloatingHelper.tsx
@@ -109,7 +109,7 @@ export class FloatingHelper extends React.Component<FloatingHelperProps> {
           className={style.closeButton}
           data-hook={DataHooks.closeButton}
           onClick={()=>this.getCloseButtonHandler(closableActions)()}
-          skin={CloseButtonSkin.white}
+          skin={appearance === Appearance.dark ? CloseButtonSkin.white: CloseButtonSkin.dark}
           size={CloseButtonSize.large}
         />
         <div data-hook={DataHooks.innerContent} className={style.innerContent}>

--- a/src/components/FloatingHelper/FloatingHelper.tsx
+++ b/src/components/FloatingHelper/FloatingHelper.tsx
@@ -9,7 +9,7 @@ import { Button } from '../Button';
 import { Skin, Size } from '../Button/constants';
 import { CloseButton, CloseButtonSkin, CloseButtonSize } from '../CloseButton';
 import { FloatingHelperContent , FloatingHelperContentProps} from './FloatingHelperContent';
-import { Appearance } from "./constants";
+import { Appearance } from './constants';
 export {Placement, AppendTo};
 import { enumValues } from '../../utils';
 

--- a/src/components/FloatingHelper/FloatingHelper.tsx
+++ b/src/components/FloatingHelper/FloatingHelper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import pick = require('lodash/pick');
-import { string, number, oneOfType, node, Requireable, ValidationMap} from 'prop-types'
+import { string, number, oneOfType, oneOf, node, Requireable, ValidationMap} from 'prop-types'
 import * as classnames from 'classnames';
 import { ClosablePopover, ClosablePopoverProps, ClosablePopoverActions, Placement, AppendTo } from './ClosablePopover';
 import style from './FloatingHelper.st.css';
@@ -9,8 +9,9 @@ import { Button } from '../Button';
 import { Skin, Size } from '../Button/constants';
 import { CloseButton, CloseButtonSkin, CloseButtonSize } from '../CloseButton';
 import { FloatingHelperContent , FloatingHelperContentProps} from './FloatingHelperContent';
-
+import { Appearance } from "./constants";
 export {Placement, AppendTo};
+import { enumValues } from '../../utils';
 
 export interface FloatingHelperOwnProps {
   /** Width HTML attribute of the content. If a number is passed then it defaults to px. e.g width={400} => width="400px" */
@@ -21,6 +22,8 @@ export interface FloatingHelperOwnProps {
   content: React.ReactNode
   /** In Controlled mode - called when the close button is clicked. In Uncontrolled mode - called when the popover is closed */
   onClose?: Function;
+  /* Appearance : `dark` or `light`. */
+  appearance?: Appearance;
 }
 
 // This HACK is only for AutoDocs to work - see issue - https://github.com/wix/wix-ui/issues/550
@@ -72,14 +75,17 @@ export class FloatingHelper extends React.Component<FloatingHelperProps> {
   static defaultProps: Partial<FloatingHelperProps> = {
     appendTo: 'window',
     width: '444px',
-    initiallyOpened: true
+    initiallyOpened: true,
+    appearance: Appearance.dark
   };
 
-  static propTypes : ValidationMap<FloatingHelperProps>= {
+  static propTypes : ValidationMap<FloatingHelperProps> = {
     ...pickedPopoverPropTypes,
     width: oneOfType([string, number]),
     target: node.isRequired,
-    content: node.isRequired // TODO: validate it is a <HelperContent>
+    content: node.isRequired, // TODO: validate it is a <HelperContent>
+    appearance: oneOf(enumValues(Appearance))
+
   };
 
   open = () => { this.closablePopoverRef.open() };
@@ -96,7 +102,7 @@ export class FloatingHelper extends React.Component<FloatingHelperProps> {
       closableActions.close
   }
 
-  renderContent(closableActions: ClosablePopoverActions, {width, content}: Partial<FloatingHelperProps>) {
+  renderContent(closableActions: ClosablePopoverActions, {width, content, appearance}: Partial<FloatingHelperProps>) {
     return (
       <div data-hook={DataHooks.contentWrapper} style={{ width }}>
         <CloseButton
@@ -107,16 +113,16 @@ export class FloatingHelper extends React.Component<FloatingHelperProps> {
           size={CloseButtonSize.large}
         />
         <div data-hook={DataHooks.innerContent} className={style.innerContent}>
-          {content}
+          {React.cloneElement(content as React.ReactElement<any>, {appearance})}
         </div>
       </div>
     )
   }
 
   render() {
-    const { children, width, content, ...rest } = this.props;
+    const { children, width, content, appearance, ...rest } = this.props;
 
-    const renderContent = (closableActions: ClosablePopoverActions)=>this.renderContent(closableActions,{width, content});
+    const renderContent = (closableActions: ClosablePopoverActions)=>this.renderContent(closableActions,{width, content, appearance});
 
     const closablePopoverProps: ClosablePopoverProps = {
       ...rest,
@@ -129,7 +135,7 @@ export class FloatingHelper extends React.Component<FloatingHelperProps> {
       <ClosablePopover
         {...closablePopoverProps}
         ref={ref => this.closablePopoverRef = ref}
-        {...style('root', {}, this.props)}
+        {...style('root', {appearance}, this.props)}
       />
     );
   };

--- a/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.st.css
+++ b/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.st.css
@@ -1,5 +1,5 @@
 .root {
-  -st-states: hasBody(boolean);
+  -st-states: hasBody(boolean), appearance(enum(dark,light));
 
   display: flex;
   flex-direction: row;

--- a/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.tsx
+++ b/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import { string, func, node } from 'prop-types';
+import { string, func, node, oneOf } from 'prop-types';
 import style from './FloatingHelperContent.st.css';
 import { Text } from '../../../components/Text';
 import { DataHooks } from './DataHooks';
 import { Button, ButtonProps, ButtonSkin, ButtonPriority, ButtonSize } from '../../Button';
 import { ActionButtonTheme } from './constants';
+import {Appearance} from '../constants';
+import { enumValues } from '../../../utils';
 
 export interface FloatingHelperContentProps {
   /** Adds text as the title */
@@ -19,31 +21,34 @@ export interface FloatingHelperContentProps {
   onActionClick?:() => void,
   /** Adds an image */
   image?: React.ReactNode;
+  /* Appearance : `dark` or `light`. */
+  appearance?: Appearance;
 }
 
 const themeToButtonProps: { [key in ActionButtonTheme]: Pick<ButtonProps, 'skin' | 'priority'> } = {
   [ActionButtonTheme.white]: { skin: ButtonSkin.white, priority: ButtonPriority.secondary },
+  [ActionButtonTheme.standard]: { skin: ButtonSkin.standard, priority: ButtonPriority.secondary },
   [ActionButtonTheme.premium]: { skin: ButtonSkin.premium, priority: ButtonPriority.primary }
 }
 
 export const FloatingHelperContent: React.SFC<FloatingHelperContentProps> = (
   props: FloatingHelperContentProps
 ) => {
-  const { title, body, actionText, onActionClick, actionTheme, image } = props;
+  const { title, body, actionText, onActionClick, actionTheme, image, appearance } = props;
 
   return (
     <div {...style('root', { hasBody: !!props.body }, props)}>
       <div>
         {title && (
           <div className={style.title}>
-            <Text data-hook={DataHooks.title} bold light>
+            <Text data-hook={DataHooks.title} bold light={appearance === Appearance.dark}>
               {title}
             </Text>
           </div>
         )}
         {body && (
           <div className={style.body}>
-            <Text data-hook={DataHooks.body} light>
+            <Text data-hook={DataHooks.body} light={appearance === Appearance.dark}>
               {body}
             </Text>
           </div>
@@ -72,9 +77,11 @@ FloatingHelperContent.propTypes = {
   body: string.isRequired,
   actionText: string,
   onActionClick: func,
-  image: node
+  image: node,
+  appearance: oneOf(enumValues(Appearance))
 };
 
 FloatingHelperContent.defaultProps = {
-  actionTheme: ActionButtonTheme.white
+  actionTheme: ActionButtonTheme.white,
+  appearance: Appearance.dark
 };

--- a/src/components/FloatingHelper/FloatingHelperContent/constants.ts
+++ b/src/components/FloatingHelper/FloatingHelperContent/constants.ts
@@ -1,4 +1,5 @@
 export enum ActionButtonTheme {
+  standard = 'standard',
   white = 'white',
-  premium = 'premium'
+  premium = 'premium',
 }

--- a/src/components/FloatingHelper/constants.ts
+++ b/src/components/FloatingHelper/constants.ts
@@ -1,0 +1,4 @@
+export enum Appearance {
+  dark = 'dark',
+  light = 'light'
+}

--- a/src/components/FloatingHelper/index.ts
+++ b/src/components/FloatingHelper/index.ts
@@ -1,1 +1,2 @@
 export * from './FloatingHelper';
+export * from './constants';

--- a/stories/FloatingHelper/SimpleExampleLight.tsx
+++ b/stories/FloatingHelper/SimpleExampleLight.tsx
@@ -7,6 +7,7 @@ export class SimpleExampleLight extends React.Component {
   render() {
     return (
       <FloatingHelper
+        data-hook="story-floating-helper-light"
         target={<span>I am a FloatingHelper target</span>}
         content={
           <FloatingHelper.Content

--- a/stories/FloatingHelper/SimpleExampleLight.tsx
+++ b/stories/FloatingHelper/SimpleExampleLight.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { FloatingHelper, Appearance } from '../../src/components/FloatingHelper';
+import Image from 'wix-ui-icons-common/Image';
+import {ActionButtonTheme} from '../../src/components/FloatingHelper/FloatingHelperContent';
+
+export class SimpleExampleLight extends React.Component {
+  render() {
+    return (
+      <FloatingHelper
+        target={<span>I am a FloatingHelper target</span>}
+        content={
+          <FloatingHelper.Content
+            title="Don’t forget to setup payments"
+            body="In order to sell your music you need to choose a payment method."
+            actionText="Ok, Take Me There"
+            onActionClick={() => null}
+            actionTheme={ActionButtonTheme.standard}
+            image={<Image style={{color: '#555555'}}  width="102" height="102" viewBox="4 4 18 18" />}
+          />
+        }
+        placement="right"
+        appearance={Appearance.light}
+      />
+    );
+  }
+}

--- a/stories/FloatingHelper/index.story.tsx
+++ b/stories/FloatingHelper/index.story.tsx
@@ -27,6 +27,7 @@ import {enumValues} from '../../src/utils';
 import {Appearance} from '../../src/components/FloatingHelper/constants';
 
 const exampleWrapperStyle = {marginTop: 100, marginBottom: 100};
+const exampleWrapperStyleLight = {paddingTop: 100, paddingBottom: 100, backgroundColor: '#F0F4F7'};
 
 export default {
   category: storySettings.kind,
@@ -115,7 +116,7 @@ export default {
       </CodeExample >
 
       <CodeExample title="Simple Example Appearance=Light" code={SimpleExampleLightRaw}>
-        <div style={exampleWrapperStyle}>
+        <div style={exampleWrapperStyleLight}>
           <SimpleExampleLight/>
         </div>
       </CodeExample >

--- a/stories/FloatingHelper/index.story.tsx
+++ b/stories/FloatingHelper/index.story.tsx
@@ -116,7 +116,7 @@ export default {
       </CodeExample >
 
       <CodeExample title="Simple Example Appearance=Light" code={SimpleExampleLightRaw}>
-        <div style={exampleWrapperStyleLight}>
+        <div style={exampleWrapperStyleLight} data-hook="appearance-light-example-container">
           <SimpleExampleLight/>
         </div>
       </CodeExample >

--- a/stories/FloatingHelper/index.story.tsx
+++ b/stories/FloatingHelper/index.story.tsx
@@ -12,6 +12,9 @@ import CodeExample from 'wix-storybook-utils/CodeExample';
 import {SimpleExample} from './SimpleExample';
 import * as SimpleExampleRaw from '!raw-loader!./SimpleExample';
 
+import {SimpleExampleLight} from './SimpleExampleLight';
+import * as SimpleExampleLightRaw from '!raw-loader!./SimpleExampleLight';
+
 import {FullExample} from './FullExample';
 import * as FullExampleRaw from '!raw-loader!./FullExample';
 
@@ -20,6 +23,8 @@ import * as ProgrammaticExampleRaw from '!raw-loader!./ProgrammaticExample';
 
 import {ControlledExample} from './ControlledExample';
 import * as ControlledExampleRaw from '!raw-loader!./ControlledExample';
+import {enumValues} from '../../src/utils';
+import {Appearance} from '../../src/components/FloatingHelper/constants';
 
 const exampleWrapperStyle = {marginTop: 100, marginBottom: 100};
 
@@ -71,7 +76,8 @@ export default {
           />
         )
       }
-    ]
+    ],
+    appearance: enumValues(Appearance)
   },
 
   examples: (
@@ -105,6 +111,12 @@ export default {
       <CodeExample title="Controlled Example" code={ControlledExampleRaw}>
         <div style={exampleWrapperStyle}>
           <ControlledExample/>
+        </div>
+      </CodeExample >
+
+      <CodeExample title="Simple Example Appearance=Light" code={SimpleExampleLightRaw}>
+        <div style={exampleWrapperStyle}>
+          <SimpleExampleLight/>
         </div>
       </CodeExample >
     </div>


### PR DESCRIPTION
Resolves - https://github.com/wix-private/wsr-issues/issues/233
## API changes
- Added `appearance` prop in `<FloatingHelper/>`
- Added `appearance` prop in `<FloatingHelperContent/>` (`appearance` is propagated from `<FloatingHelper/>`)
- Allow `<FloatingHelperContent actionTheme={ActionButtonTheme.standard}/>`

## Other required changed
- Added 'dark' skin to CloseButton

## Also fixed
- Add z-index to  arrow so it will be above the box-shadow (affects the default appearance dark as well)