### PR TITLE
Removed invalid stylable imports

### DIFF
--- a/src/components/Label/Label.st.css
+++ b/src/components/Label/Label.st.css
@@ -1,8 +1,8 @@
 :import {
   -st-from: "wix-ui-core/index.st.css";
-  -st-named: Label, LabelStyle;
+  -st-named: Label;
 }
-  
+
 :import {
   -st-from: "../../palette.st.css";
   -st-named: secondaryText;
@@ -14,7 +14,7 @@
 }
 
 .root {
-  -st-extends: Label, LabelStyle;
+  -st-extends: Label;
   -st-states: size(enum(small, medium));
   color: value(secondaryText);
   font-family: value(fontLight);

--- a/src/components/Tooltip/Tooltip.st.css
+++ b/src/components/Tooltip/Tooltip.st.css
@@ -5,7 +5,7 @@
 
 :import {
   -st-from: "../../palette.st.css";
-  -st-named: tableSelected, brandSecondary, backgroundSecondary, main, mainHover, disabled, successNotifications, dangerNotifications, ctaHover, danger, successHover, dangerHover, disabledDividers;
+  -st-named: brandSecondary, backgroundSecondary, main, mainHover, disabled, danger, successHover, dangerHover;
 }
 
 :import {


### PR DESCRIPTION
There are some warnings regarding importing variables that do not exist.
<img width="962" alt="screen shot 2018-09-28 at 10 38 51 pm" src="https://user-images.githubusercontent.com/5933939/46228888-6dc23e00-c370-11e8-94b1-d2d293237844.png">
<img width="881" alt="screen shot 2018-09-28 at 10 39 21 pm" src="https://user-images.githubusercontent.com/5933939/46228892-70249800-c370-11e8-9c3a-6bb2a55409fe.png">

This creates warnings in `wix-style-react` which is dependent on this package.