### PR TITLE
Added premium badge skin

### DIFF
--- a/src/components/Badge/Badge.st.css
+++ b/src/components/Badge/Badge.st.css
@@ -12,10 +12,11 @@
   -st-from: "../../colors.st.css";
   -st-named:
     B10, B20, B30,
-    D20, D40,
+    D20, D40, D80,
     F00,
     G10, G30,
     O10,
+    P10,
     R10, R30,
     Y10,
     WHITE,
@@ -171,6 +172,14 @@
   );
 }
 
+.root:type(transparent):skin(premium) {
+  -st-mixin: BadgeStyle(
+          backgroundColor transparent,
+          borderColor transparent,
+          color value(P10)
+  );
+}
+
 /* type = solid */
 .root:type(solid):skin(general) {
   -st-mixin: BadgeStyle(
@@ -252,6 +261,14 @@
   );
 }
 
+.root:type(solid):skin(premium) {
+  -st-mixin: BadgeStyle(
+          backgroundColor value(P10),
+          borderColor value(P10),
+          color value(D80)
+  );
+}
+
 /* type = outlined */
 .root:type(outlined):skin(general) {
   -st-mixin: BadgeStyle(
@@ -330,6 +347,14 @@
     borderColor value(R30),
     backgroundColor value(WHITE),
     color value(secondaryText)
+  );
+}
+
+.root:type(outlined):skin(premium) {
+  -st-mixin: BadgeStyle(
+          borderColor value(P10),
+          backgroundColor value(WHITE),
+          color value(P10)
   );
 }
 

--- a/src/components/Badge/constants.ts
+++ b/src/components/Badge/constants.ts
@@ -1,4 +1,4 @@
-export type Skin = 'general' | 'standard' | 'danger' | 'success' | 'neutral' | 'warning' | 'urgent'  | 'neutralStandard' | 'neutralSuccess' | 'nutralDanger';
+export type Skin = 'general' | 'standard' | 'danger' | 'success' | 'neutral' | 'warning' | 'urgent'  | 'neutralStandard' | 'neutralSuccess' | 'nutralDanger' | 'premium';
 
 export type Type = 'solid' | 'outlined' | 'transparent';
 
@@ -14,7 +14,8 @@ export const SKIN = {
   urgent: 'urgent',
   neutralStandard: 'neutralStandard',
   neutralSuccess: 'neutralSuccess',
-  neutralDanger: 'neutralDanger'
+  neutralDanger: 'neutralDanger',
+  premium: 'premium'
 };
 
 export const TYPE = {


### PR DESCRIPTION
**What changed**
add premium skin to Badge component
**Why**
According to design in zeplin (https://app.zeplin.io/project/5864e02695b5754a69f56150/screen/5bd964a361e1ec76383aa9bb) we should have premium badge color, but now it is missed

Please, review and merge as soon as possible =)