### PR TITLE
<LinearProgressBar/> - fix error in driver when component is not rendered

### DIFF
--- a/src/components/LinearProgressBar/LinearProgressBar.driver.ts
+++ b/src/components/LinearProgressBar/LinearProgressBar.driver.ts
@@ -1,9 +1,10 @@
-import {ComponentFactory} from 'wix-ui-test-utils/driver-factory';
+import { ComponentFactory } from 'wix-ui-test-utils/driver-factory';
 import {
-  linearProgressBarDriverFactory as coreLinearProgressBarDriverFactory,
-  LinearProgressBarDriver as CoreLinearProgressBarDriver } from 'wix-ui-core/drivers/vanilla';
-import {BaseDriver, DriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {tooltipDriverFactory} from '../Tooltip/Tooltip.driver'
+    linearProgressBarDriverFactory as coreLinearProgressBarDriverFactory,
+    LinearProgressBarDriver as CoreLinearProgressBarDriver
+} from 'wix-ui-core/drivers/vanilla';
+import { BaseDriver, DriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { tooltipDriverFactory } from '../Tooltip/Tooltip.driver'
 
 export interface LinearProgressBarDriver extends CoreLinearProgressBarDriver {
     /* Returns true if the tooltip is shown */
@@ -18,15 +19,15 @@ export interface LinearProgressBarDriver extends CoreLinearProgressBarDriver {
 }
 
 export const linearProgressBarDriverFactory: DriverFactory<LinearProgressBarDriver> = ({ element, eventTrigger, wrapper }: ComponentFactory): LinearProgressBarDriver => {
-    const tooltipDriver = tooltipDriverFactory({element: element.querySelector(`[data-hook='linear-progressbar-tooltip']`), wrapper, eventTrigger});
-    const coreProgressBarDriver = coreLinearProgressBarDriverFactory({element, wrapper, eventTrigger});
+    const createTooltipDriver = () => tooltipDriverFactory({ element: element.querySelector(`[data-hook='linear-progressbar-tooltip']`), wrapper, eventTrigger });
+    const coreProgressBarDriver = coreLinearProgressBarDriverFactory({ element, wrapper, eventTrigger });
     const errorIcon = () => element.querySelector(`[data-hook='error-icon']`);
     const successIcon = () => element.querySelector(`[data-hook='success-icon']`);
 
     return {
         ...coreProgressBarDriver,
-        isTooltipShown: () => tooltipDriver.isContentElementExists(),
-        getTooltip: () => tooltipDriver, 
+        isTooltipShown: () => createTooltipDriver().isContentElementExists(),
+        getTooltip: () => createTooltipDriver(),
         isErrorIconShown: () => !!errorIcon(),
         isSuccessIconShown: () => !!successIcon()
     };

--- a/src/components/LinearProgressBar/LinearProgressBar.spec.tsx
+++ b/src/components/LinearProgressBar/LinearProgressBar.spec.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {linearProgressBarDriverFactory} from './LinearProgressBar.driver';
-import {LinearProgressBar, LinearProgressBarProps} from './LinearProgressBar';
+import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { linearProgressBarDriverFactory } from './LinearProgressBar.driver';
+import { LinearProgressBar, LinearProgressBarProps } from './LinearProgressBar';
 import { linearProgressBarTestkitFactory } from '../../testkit';
-import {linearProgressBarTestkitFactory as enzymeLinearProgressBarTestkitFactory} from '../../testkit/enzyme';
+import { linearProgressBarTestkitFactory as enzymeLinearProgressBarTestkitFactory } from '../../testkit/enzyme';
 import { runTestkitExistsSuite } from '../../common/testkitTests';
 
 describe('LinearProgressBar', () => {
@@ -45,10 +45,20 @@ describe('LinearProgressBar', () => {
         }
 
         it('should display success icon', () => {
-            const driver = createDriver(<LinearProgressBar {...successProps}/>);
+            const driver = createDriver(<LinearProgressBar {...successProps} />);
             expect(driver.isSuccessIconShown()).toBe(true);
         });
 
+    });
+
+    it(`should not throw an error when component isn't rendered`, () => {
+        const driverFactoryWrapper = { createDriver }
+        const isComponentRendered = false;
+
+        jest.spyOn(driverFactoryWrapper, 'createDriver');
+        driverFactoryWrapper.createDriver(<div>{isComponentRendered && <LinearProgressBar />}</div>);
+
+        expect(driverFactoryWrapper.createDriver).not.toThrow();
     });
 
     runTestkitExistsSuite({


### PR DESCRIPTION
This PR resolves an issue that a `TypeError` occurs when we initialize the driver of `LinearProgressBar` with a wrapper that doesn't actually render that component.

For instance, the following code, which throws `TypeError: element.querySelector is not a function`:
```javascript
import { LinearProgressBar } from 'wix-ui-backoffice/LinearProgressBar';
import { linearProgressBarTestkitFactory as enzymeLinearProgressBarTestkitFactory } from 'wix-style-react/dist/testkit/enzyme';

const wrapper = mount(<div>{false && <LinearProgressBar />}</div>);
const linearProgressBarDriver = enzymeLinearProgressBarTestkitFactory({wrapper});

expect(linearProgressBarDriver.exists()).toBeTruthy();
```