### PR TITLE
<CircularProgressBar/> - fix error in driver when component is not rendered 

### DIFF
--- a/src/components/CircularProgressBar/CircularProgressBar.driver.ts
+++ b/src/components/CircularProgressBar/CircularProgressBar.driver.ts
@@ -1,12 +1,13 @@
-import {ComponentFactory} from 'wix-ui-test-utils/driver-factory';
+import { ComponentFactory } from 'wix-ui-test-utils/driver-factory';
 import {
-  circularProgressBarDriverFactory as coreCircularProgressBarDriverFactory,
-  CircularProgressBarDriver as CoreCircularProgressBarDriver } from 'wix-ui-core/drivers/vanilla';
-import {BaseDriver, DriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {tooltipDriverFactory} from '../Tooltip/Tooltip.driver'
-import {StylableDOMUtil} from '@stylable/dom-test-kit';
+    circularProgressBarDriverFactory as coreCircularProgressBarDriverFactory,
+    CircularProgressBarDriver as CoreCircularProgressBarDriver
+} from 'wix-ui-core/drivers/vanilla';
+import { BaseDriver, DriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { tooltipDriverFactory } from '../Tooltip/Tooltip.driver'
+import { StylableDOMUtil } from '@stylable/dom-test-kit';
 import style from './CircularProgressBar.st.css';
-import {Size} from './constants';
+import { Size } from './constants';
 
 export interface CircularProgressBarDriver extends CoreCircularProgressBarDriver {
     /* Returns true if the tooltip is shown */
@@ -23,8 +24,8 @@ export interface CircularProgressBarDriver extends CoreCircularProgressBarDriver
 }
 
 export const circularProgressBarDriverFactory: DriverFactory<CircularProgressBarDriver> = ({ element, eventTrigger, wrapper }: ComponentFactory): CircularProgressBarDriver => {
-    const tooltipDriver = tooltipDriverFactory({element: element.querySelector(`[data-hook='circular-progressbar-tooltip']`), wrapper, eventTrigger});
-    const coreProgressBarDriver = coreCircularProgressBarDriverFactory({element, wrapper, eventTrigger});
+    const createTooltipDriver = () => tooltipDriverFactory({ element: element.querySelector(`[data-hook='circular-progressbar-tooltip']`), wrapper, eventTrigger });
+    const coreProgressBarDriver = coreCircularProgressBarDriverFactory({ element, wrapper, eventTrigger });
     const errorIcon = () => element.querySelector(`[data-hook='error-icon']`);
     const successIcon = () => element.querySelector(`[data-hook='success-icon']`);
     const progressBar = () => element.querySelector(`[data-hook='circular-progress-bar']`);
@@ -32,8 +33,8 @@ export const circularProgressBarDriverFactory: DriverFactory<CircularProgressBar
 
     return {
         ...coreProgressBarDriver,
-        isTooltipShown: () => tooltipDriver.isContentElementExists(),
-        getTooltip: () => tooltipDriver, 
+        isTooltipShown: () => createTooltipDriver().isContentElementExists(),
+        getTooltip: () => createTooltipDriver(),
         isErrorIconShown: () => !!errorIcon(),
         isSuccessIconShown: () => !!successIcon(),
         getSize: () => stylableDOMUtil.getStyleState(progressBar(), 'size') as Size,

--- a/src/components/CircularProgressBar/CircularProgressBar.spec.tsx
+++ b/src/components/CircularProgressBar/CircularProgressBar.spec.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import {createDriverFactory} from 'wix-ui-test-utils/driver-factory';
-import {circularProgressBarDriverFactory} from './CircularProgressBar.driver';
-import {CircularProgressBar, CircularProgressBarProps} from './CircularProgressBar';
-import {circularProgressBarTestkitFactory} from '../../testkit';
-import {circularProgressBarTestkitFactory as CircularLinearProgressBarTestkitFactory} from '../../testkit/enzyme';
-import {runTestkitExistsSuite} from '../../common/testkitTests';
-import {Size} from './constants';
+import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
+import { circularProgressBarDriverFactory } from './CircularProgressBar.driver';
+import { CircularProgressBar, CircularProgressBarProps } from './CircularProgressBar';
+import { circularProgressBarTestkitFactory } from '../../testkit';
+import { circularProgressBarTestkitFactory as CircularLinearProgressBarTestkitFactory } from '../../testkit/enzyme';
+import { runTestkitExistsSuite } from '../../common/testkitTests';
+import { Size } from './constants';
 
 describe('CircularProgressBar', () => {
   const createDriver = createDriverFactory(circularProgressBarDriverFactory);
@@ -41,7 +41,7 @@ describe('CircularProgressBar', () => {
     }
 
     it('should display success icon', () => {
-      const driver = createDriver(<CircularProgressBar {...successProps}/>);
+      const driver = createDriver(<CircularProgressBar {...successProps} />);
       expect(driver.isSuccessIconShown()).toBe(true);
     });
   });
@@ -49,7 +49,7 @@ describe('CircularProgressBar', () => {
   describe('size prop', () => {
     Object.keys(Size).forEach((size: Size) => {
       it(`should be ${size}`, () => {
-        const driver = createDriver(<CircularProgressBar {...defaultProps} size={size}/>);
+        const driver = createDriver(<CircularProgressBar {...defaultProps} size={size} />);
         expect(driver.getSize()).toBe(size);
       });
     });
@@ -58,6 +58,16 @@ describe('CircularProgressBar', () => {
       const driver = createDriver(<CircularProgressBar {...defaultProps} />);
       expect(driver.getSize()).toBe(Size.medium);
     });
+  });
+
+  it(`should not throw an error when component isn't rendered`, () => {
+    const driverFactoryWrapper = { createDriver }
+    const isComponentRendered = false;
+
+    jest.spyOn(driverFactoryWrapper, 'createDriver');
+    driverFactoryWrapper.createDriver(<div>{isComponentRendered && <CircularProgressBar />}</div>);
+
+    expect(driverFactoryWrapper.createDriver).not.toThrow();
   });
 
   runTestkitExistsSuite({


### PR DESCRIPTION
Resolves https://github.com/wix/wix-style-react/issues/2259

The issue details are described here: https://github.com/wix/wix-ui-backoffice/pull/262