### PR TITLE
FloatingHelperContent: fix action button styling

### DIFF
--- a/src/components/Button/constants.ts
+++ b/src/components/Button/constants.ts
@@ -1,18 +1,18 @@
 export enum Skin {
   standard = 'standard',
-  white = 'white',
+  white = 'light',
   destructive = 'destructive',
   premium = 'premium'
-};
+}
 
 export enum Priority {
   primary = 'primary',
-  secondary = 'secondary',
-};
+  secondary = 'secondary'
+}
 
 export enum Size {
   large = 'large',
   medium = 'medium',
   small = 'small',
-  tiny = 'tiny',
+  tiny = 'tiny'
 }

--- a/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.driver.ts
+++ b/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.driver.ts
@@ -1,27 +1,42 @@
 import { DataHooks } from './DataHooks';
 import { BaseDriver, DriverFactory } from 'wix-ui-test-utils/driver-factory';
-import { buttonDriverFactory, ButtonDriver } from '../../Button/Button.driver';
 import { Skin } from '../../Button/constants';
+
+import style from './FloatingHelperContent.st.css';
 
 export interface FloatingHelperContentDriver extends BaseDriver {
   /** checks if the element exists */
-  exists: () => boolean;
+  exists(): boolean;
+
   /** checks if title exists */
-  hasTitle: () => boolean;
+  hasTitle(): boolean;
+
   /** checks if text content exists */
-  hasBody: () => boolean;
+  hasBody(): boolean;
+
   /** checks if an image exists */
-  hasImage: () => boolean;
+  hasImage(): boolean;
+
   /** checks if the action button exists */
-  hasActionButton: () => boolean;
+  hasActionButton(): boolean;
+
   /** Get the text content of the title */
-  getTitleContent: () => string;
+  getTitleContent(): string;
+
   /** Get the text content of the helper's text */
-  getBodyContent: () => string;
-  /** Get the action button test driver */
-  getActionButtonDriver: () => ButtonDriver;
+  getBodyContent(): string;
+
   /** Get image HTML element*/
-  getImage: () => HTMLElement;
+  getImage(): HTMLElement;
+
+  /** Get text of action button */
+  getActionButtonText(): string;
+
+  /** naive way to check for stylable class */
+  matchesActionButtonClassName(): boolean;
+
+  /** click on the action button */
+  clickActionButton(): void;
 }
 
 export const floatingHelperContentDriverFactory: DriverFactory<
@@ -40,12 +55,18 @@ export const floatingHelperContentDriverFactory: DriverFactory<
     hasBody: () => !!body(),
     hasActionButton: () => !!actionButton(),
     hasImage: () => !!image(),
-    getImage: ()=> image() && image().childNodes[0] as HTMLElement,
-    getActionButtonDriver: () => buttonDriverFactory({
-      ...factoryParams,
-      element: actionButton()
-    }),
+    getImage: () => image() && (image().childNodes[0] as HTMLElement),
     getTitleContent: () => title().textContent,
     getBodyContent: () => body().textContent,
+    getActionButtonText: () => actionButton().textContent
+    matchesActionButtonClassName: className => !!Array.from(actionButton().classList).find(c => c.includes(className)),
+    clickActionButton: () => {
+      const button = actionButton();
+      if(button) {
+        factoryParams.eventTrigger.click(button);
+      } else {
+        throw new Error('Error: Unable to click action button, unable to find it', element.outerHTML)
+      }
+    }
   };
 };

--- a/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.driver.ts
+++ b/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.driver.ts
@@ -33,7 +33,7 @@ export interface FloatingHelperContentDriver extends BaseDriver {
   getActionButtonText(): string;
 
   /** naive way to check for stylable class */
-  matchesActionButtonClassName(): boolean;
+  matchesActionButtonClassName(className: string): boolean;
 
   /** click on the action button */
   clickActionButton(): void;
@@ -58,15 +58,9 @@ export const floatingHelperContentDriverFactory: DriverFactory<
     getImage: () => image() && (image().childNodes[0] as HTMLElement),
     getTitleContent: () => title().textContent,
     getBodyContent: () => body().textContent,
-    getActionButtonText: () => actionButton().textContent
-    matchesActionButtonClassName: className => !!Array.from(actionButton().classList).find(c => c.includes(className)),
-    clickActionButton: () => {
-      const button = actionButton();
-      if(button) {
-        factoryParams.eventTrigger.click(button);
-      } else {
-        throw new Error('Error: Unable to click action button, unable to find it', element.outerHTML)
-      }
-    }
+    getActionButtonText: () => actionButton().textContent,
+    matchesActionButtonClassName: className =>
+      !!Array.from(actionButton().classList).find(c => c.includes(className)),
+    clickActionButton: () => factoryParams.eventTrigger.click(actionButton())
   };
 };

--- a/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.spec.tsx
+++ b/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.spec.tsx
@@ -8,6 +8,7 @@ import {
 import { ButtonSkin, ButtonPriority } from '../../Button';
 import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
 import { mount } from 'enzyme';
+import defaults = require('lodash/defaults');
 
 const noop = () => null;
 
@@ -152,9 +153,10 @@ function withDefaultsHOC<P>({
   component: React.SFC<P>;
   defaultProps: P;
 }): React.SFC<Partial<P>> {
-  return (partialProps?: Partial<P>) =>
-    React.createElement(component, {
-      ...defaultProps,
-      ...partialProps
-    });
+  return (partialProps?: Partial<P>) => {
+    return React.createElement(
+      component,
+      defaults({}, partialProps, defaultProps)
+    );
+  };
 }

--- a/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.spec.tsx
+++ b/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.spec.tsx
@@ -1,19 +1,24 @@
 import * as React from 'react';
-import defaults = require('lodash/defaults');
 import { floatingHelperContentDriverFactory } from './FloatingHelperContent.driver';
-import { FloatingHelperContent, FloatingHelperContentProps, ActionButtonTheme } from '.';
+import {
+  FloatingHelperContent,
+  FloatingHelperContentProps,
+  ActionButtonTheme
+} from '.';
 import { ButtonSkin, ButtonPriority } from '../../Button';
 import { createDriverFactory } from 'wix-ui-test-utils/driver-factory';
 import { mount } from 'enzyme';
 
-const noop = ()=> null;
+const noop = () => null;
 
 describe('FloatingHelperContent', () => {
   const createDriver = createDriverFactory(floatingHelperContentDriverFactory);
-  
-  const FloatingHelperContentBuilder = withDefaultsHOC<FloatingHelperContentProps>({
+
+  const FloatingHelperContentBuilder = withDefaultsHOC<
+    FloatingHelperContentProps
+  >({
     component: FloatingHelperContent,
-    defaultProps: { body:'this is the body' }
+    defaultProps: { body: 'this is the body' }
   });
 
   describe('title prop', () => {
@@ -23,7 +28,9 @@ describe('FloatingHelperContent', () => {
     });
 
     it('should have title with proper content', () => {
-      const driver = createDriver(<FloatingHelperContentBuilder title="title" />);
+      const driver = createDriver(
+        <FloatingHelperContentBuilder title="title" />
+      );
       expect(driver.hasTitle()).toBeTruthy();
       expect(driver.getTitleContent()).toBe('title');
     });
@@ -38,7 +45,10 @@ describe('FloatingHelperContent', () => {
   });
 
   describe('action button', () => {
-    const actionProps : Partial<FloatingHelperContentProps> = {actionText:'Click me !', onActionClick:noop};
+    const actionProps: Partial<FloatingHelperContentProps> = {
+      actionText: 'Click me !',
+      onActionClick: noop
+    };
 
     it('should not have action button by default', () => {
       const driver = createDriver(<FloatingHelperContentBuilder />);
@@ -46,69 +56,105 @@ describe('FloatingHelperContent', () => {
     });
 
     it('should not have action button if only actionText is passed', () => {
-      const driver = createDriver(<FloatingHelperContentBuilder actionText="Click Me!"/>);
+      const driver = createDriver(
+        <FloatingHelperContentBuilder actionText="Click Me!" />
+      );
       expect(driver.hasActionButton()).toBeFalsy();
     });
 
     it('should not have action button if only onActionClick is passed', () => {
-      const driver = createDriver(<FloatingHelperContentBuilder onActionClick={noop} />);
+      const driver = createDriver(
+        <FloatingHelperContentBuilder onActionClick={noop} />
+      );
       expect(driver.hasActionButton()).toBeFalsy();
     });
 
     it('should not have action button if actionText is an empty string', () => {
-      const driver = createDriver(<FloatingHelperContentBuilder onActionClick={noop} actionText=""/>);
+      const driver = createDriver(
+        <FloatingHelperContentBuilder onActionClick={noop} actionText="" />
+      );
       expect(driver.hasActionButton()).toBeFalsy();
     });
 
     it('should have action button with correct text', () => {
-      const actionText = 'Click Me!'
-      const driver = createDriver(<FloatingHelperContentBuilder actionText={actionText} onActionClick={noop}/>);
+      const actionText = 'Click Me!';
+      const driver = createDriver(
+        <FloatingHelperContentBuilder
+          actionText={actionText}
+          onActionClick={noop}
+        />
+      );
       expect(driver.hasActionButton()).toBeTruthy();
-      expect(driver.getActionButtonDriver().getTextContent()).toBe(actionText);
+      expect(driver.getActionButtonText()).toBe(actionText);
     });
 
     it('should have button with skin=white and priority=secondary by default', () => {
-      const driver = createDriver(<FloatingHelperContentBuilder {...actionProps} />);
-      expect(driver.getActionButtonDriver().getSkin()).toBe(ButtonSkin.white);
-      expect(driver.getActionButtonDriver().getPriority()).toBe(ButtonPriority.secondary);
+      const driver = createDriver(
+        <FloatingHelperContentBuilder {...actionProps} />
+      );
+      expect(driver.matchesActionButtonClassName(ButtonSkin.white)).toBe(true);
+      expect(
+        driver.matchesActionButtonClassName(ButtonPriority.secondary)
+      ).toBe(true);
     });
 
     it('should have button with skin=premium and priority=primary', () => {
-      const driver = createDriver(<FloatingHelperContentBuilder {...actionProps} actionTheme={ActionButtonTheme.premium} />);
-      expect(driver.getActionButtonDriver().getSkin()).toBe(ButtonSkin.premium);
-      expect(driver.getActionButtonDriver().getPriority()).toBe(ButtonPriority.primary);
+      const driver = createDriver(
+        <FloatingHelperContentBuilder
+          {...actionProps}
+          actionTheme={ActionButtonTheme.premium}
+        />
+      );
+      expect(driver.matchesActionButtonClassName(ButtonSkin.premium)).toBe(
+        true
+      );
     });
 
     it('should call onClick when action button clicked', () => {
       const spy = jest.fn();
-      const driver = createDriver(<FloatingHelperContentBuilder actionText="Click me!" onActionClick={spy} />);
-      driver.getActionButtonDriver().click();
+      const driver = createDriver(
+        <FloatingHelperContentBuilder
+          actionText="Click me!"
+          onActionClick={spy}
+        />
+      );
+      driver.clickActionButton();
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('image prop', () => {
     it('should not be visible by default', () => {
-      const driver = createDriver(<FloatingHelperContentBuilder actionText="Click me!" />);
+      const driver = createDriver(
+        <FloatingHelperContentBuilder actionText="Click me!" />
+      );
       expect(driver.hasImage()).toBeFalsy();
     });
 
     it('should render the image', () => {
-      const driver = createDriver(<FloatingHelperContentBuilder image={<div>🤔</div>} />);
+      const driver = createDriver(
+        <FloatingHelperContentBuilder image={<div>🤔</div>} />
+      );
       expect(driver.hasImage()).toBeTruthy();
       expect(driver.getImage()).toEqual(mount(<div>🤔</div>).getDOMNode());
     });
   });
 });
 
-// TODO: consider putting this in 'test/utils'
 /**
  * Create a Component with applied default props.
  * The new component can receive Partial<P> instead of P.
  */
-function withDefaultsHOC<P>({component,defaultProps}:{component: React.SFC<P>, defaultProps: P}): React.SFC<Partial<P>> {
-  return (partialProps?: Partial<P>) => {
-    return React.createElement(component, defaults({}, partialProps, defaultProps));
-  }
+function withDefaultsHOC<P>({
+  component,
+  defaultProps
+}: {
+  component: React.SFC<P>;
+  defaultProps: P;
+}): React.SFC<Partial<P>> {
+  return (partialProps?: Partial<P>) =>
+    React.createElement(component, {
+      ...defaultProps,
+      ...partialProps
+    });
 }
-

--- a/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.tsx
+++ b/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.tsx
@@ -1,10 +1,22 @@
 import * as React from 'react';
+import * as classnames from 'classnames';
+
 import style from './FloatingHelperContent.st.css';
 import { Text } from '../../../components/Text';
 import { DataHooks } from './DataHooks';
-import { Button, ButtonProps, ButtonSkin, ButtonPriority, ButtonSize } from '../../Button';
+import {
+  Button,
+  ButtonProps,
+  ButtonSkin,
+  ButtonPriority,
+  ButtonSize
+} from '../../Button';
+
+import { ButtonNext } from 'wix-ui-core/button-next';
+import { button } from 'wix-ui-core/themes/backoffice';
+
 import { ActionButtonTheme } from './constants';
-import {Appearance} from '../constants';
+import { Appearance } from '../constants';
 import { enumValues } from '../../../utils';
 
 export interface FloatingHelperContentProps {
@@ -17,56 +29,89 @@ export interface FloatingHelperContentProps {
   /** Sets the theme of the action button */
   actionTheme?: ActionButtonTheme;
   /** When both onActionClick & actionText are provided, will make an action button appear and invoke onActionClick() upon click */
-  onActionClick?:() => void,
+  onActionClick?: () => void;
   /** Adds an image */
   image?: React.ReactNode;
   /* Appearance : `dark` or `light`. */
   appearance?: Appearance;
 }
 
-const themeToButtonProps: { [key in ActionButtonTheme]: Pick<ButtonProps, 'skin' | 'priority'> } = {
-  [ActionButtonTheme.white]: { skin: ButtonSkin.white, priority: ButtonPriority.secondary },
-  [ActionButtonTheme.standard]: { skin: ButtonSkin.standard, priority: ButtonPriority.secondary },
-  [ActionButtonTheme.premium]: { skin: ButtonSkin.premium, priority: ButtonPriority.primary }
-}
+const themeToButtonProps: {
+  [key in ActionButtonTheme]: Pick<ButtonProps, 'skin' | 'priority'>
+} = {
+  [ActionButtonTheme.white]: {
+    skin: ButtonSkin.white,
+    priority: ButtonPriority.secondary
+  },
+  [ActionButtonTheme.standard]: {
+    skin: ButtonSkin.standard,
+    priority: ButtonPriority.secondary
+  },
+  [ActionButtonTheme.premium]: {
+    skin: ButtonSkin.premium,
+    priority: ButtonPriority.primary
+  }
+};
 
 export const FloatingHelperContent: React.SFC<FloatingHelperContentProps> = (
   props: FloatingHelperContentProps
 ) => {
-  const { title, body, actionText, onActionClick, actionTheme, image, appearance } = props;
+  const {
+    title,
+    body,
+    actionText,
+    onActionClick,
+    actionTheme,
+    image,
+    appearance
+  } = props;
 
   return (
     <div {...style('root', { hasBody: !!props.body }, props)}>
       <div>
         {title && (
           <div className={style.title}>
-            <Text data-hook={DataHooks.title} bold light={appearance === Appearance.dark}>
+            <Text
+              data-hook={DataHooks.title}
+              bold
+              light={appearance === Appearance.dark}
+            >
               {title}
             </Text>
           </div>
         )}
         {body && (
           <div className={style.body}>
-            <Text data-hook={DataHooks.body} light={appearance === Appearance.dark}>
+            <Text
+              data-hook={DataHooks.body}
+              light={appearance === Appearance.dark}
+            >
               {body}
             </Text>
           </div>
         )}
-        {actionText && onActionClick &&
-          actionText.length > 0 && (
-            <Button
-              className={style.action}
-              data-hook={DataHooks.actionButton}
-              skin={themeToButtonProps[actionTheme].skin}
-              priority={themeToButtonProps[actionTheme].priority}
-              size={ButtonSize.small}
-              onClick={onActionClick}
-            >
-              {actionText}
-            </Button>
-          )}
+        {actionText && onActionClick && actionText.length > 0 && (
+          <ButtonNext
+            className={classnames(
+              style.action,
+              button(
+                themeToButtonProps[actionTheme].skin,
+                themeToButtonProps[actionTheme].priority,
+                ButtonSize.small
+              )
+            )}
+            data-hook={DataHooks.actionButton}
+            onClick={onActionClick}
+          >
+            {actionText}
+          </ButtonNext>
+        )}
       </div>
-      {image && <div data-hook={DataHooks.image} className={style.image}>{image}</div>}
+      {image && (
+        <div data-hook={DataHooks.image} className={style.image}>
+          {image}
+        </div>
+      )}
     </div>
   );
 };

--- a/stories/FloatingHelper/SimpleExampleLight.tsx
+++ b/stories/FloatingHelper/SimpleExampleLight.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
-import { FloatingHelper, Appearance } from '../../src/components/FloatingHelper';
+import {
+  FloatingHelper,
+  Appearance
+} from '../../src/components/FloatingHelper';
 import Image from 'wix-ui-icons-common/Image';
-import {ActionButtonTheme} from '../../src/components/FloatingHelper/FloatingHelperContent';
+import { ActionButtonTheme } from '../../src/components/FloatingHelper/FloatingHelperContent';
 
 export class SimpleExampleLight extends React.Component {
   render() {
@@ -14,9 +17,16 @@ export class SimpleExampleLight extends React.Component {
             title="Don’t forget to setup payments"
             body="In order to sell your music you need to choose a payment method."
             actionText="Ok, Take Me There"
+            actionTheme="standard"
             onActionClick={() => null}
-            actionTheme={ActionButtonTheme.standard}
-            image={<Image style={{color: '#555555'}}  width="102" height="102" viewBox="4 4 18 18" />}
+            image={
+              <Image
+                style={{ color: '#555555' }}
+                width="102"
+                height="102"
+                viewBox="4 4 18 18"
+              />
+            }
           />
         }
         placement="right"


### PR DESCRIPTION
 `FloatingHelperContent` uses deprecated Button from `wix-ui-core` which
results in falsy UI (notice button borders)

![2019-03-25-113917_screenshot](https://user-images.githubusercontent.com/4284659/54909540-2669d400-4ef3-11e9-9d47-44e18b5a86f4.png)

even worse with `appearance="light"`

![2019-03-25-114429_screenshot](https://user-images.githubusercontent.com/4284659/54909645-5fa24400-4ef3-11e9-996a-269987a3bc9e.png)


this PR refactors `FloatingHelperContent` to use `ButtonNext` with
appropriate styling.

![2019-03-25-114312_screenshot](https://user-images.githubusercontent.com/4284659/54909576-371a4a00-4ef3-11e9-89a8-4777e5fa7f39.png)

![2019-03-25-114524_screenshot](https://user-images.githubusercontent.com/4284659/54909717-83658a00-4ef3-11e9-9ed3-7b4b83066803.png)

on a side note, this component is quite overengineered, it's composed of
at least three components, `appearance="light"` also requires `actionTheme="standard"` for some reason. Ideally should be a simple abstraction over Popover and live within wix-style-react, but that's out of scope of this PR. Now it deals only with a bug fix.