### PR TITLE
<Tooltip/> - set showDelay to 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "date-fns": "^1.29.0",
     "lodash": "^4.17.5",
     "shallowequal": "^1.1.0",
-    "wix-ui-core": "2.0.95",
+    "wix-ui-core": "^2.0.95",
     "wix-ui-icons-common": "^2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "date-fns": "^1.29.0",
     "lodash": "^4.17.5",
     "shallowequal": "^1.1.0",
-    "wix-ui-core": "2.0.96",
+    "wix-ui-core": "2.0.95",
     "wix-ui-icons-common": "^2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "date-fns": "^1.29.0",
     "lodash": "^4.17.5",
     "shallowequal": "^1.1.0",
-    "wix-ui-core": "^2.0.63",
+    "wix-ui-core": "2.0.96",
     "wix-ui-icons-common": "^2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "yoshi build && npm run convert-modules && import-path --path src/components --dts && build-storybook",
-    "test": ":",
+    "test": "npm run test:unit && npm run test:e2e",
     "posttest": "npm run lint",
     "test:watch": "yoshi test --jest --watch",
     "test:unit": "yoshi test --jest",

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
   Tooltip as CoreTooltip,
-  TooltipProps as CoreTooltipProps
+  TooltipProps as CoreTooltipProps,
 } from 'wix-ui-core/dist/src/components/tooltip';
 import { AppendTo } from 'wix-ui-core/dist/src/components/popover';
 import style from './Tooltip.st.css';
@@ -35,7 +35,7 @@ const defaultProps = {
   alignment: 'center',
   showTrigger: 'mouseenter',
   hideTrigger: 'mouseleave',
-  showDelay: 200,
+  showDelay: 0,
   hideDelay: 0,
   zIndex: 2000,
   maxWidth: '204px',
@@ -69,7 +69,7 @@ const TooltipBO = withStylable<CoreTooltipProps, TooltipProps>(
     disabled,
     size,
     relative,
-    shouldUpdatePosition
+    shouldUpdatePosition,
   }) => ({
     [`placement-${placement}`]: true,
     [alignment]: true,
@@ -82,7 +82,7 @@ const TooltipBO = withStylable<CoreTooltipProps, TooltipProps>(
     appendTo,
     [size]: true,
     relative,
-    shouldUpdatePosition
+    shouldUpdatePosition,
   }),
   defaultProps
 );
@@ -108,7 +108,7 @@ export const Tooltip: React.SFC<CoreTooltipProps & TooltipProps> = props => {
         color,
         lineHeight,
         zIndex,
-        padding
+        padding,
       }}
     >
       {content}


### PR DESCRIPTION
This PR makes sure that Tooltip delay is set to 0. The issue was introduced when core tooltip suddenly started to support such prop which caused all of the unit tests in wix-ui-backoffice to break.  I am assuming that users were using this tooltip with broken functioning of showDelay so setting it to 0 now that it works will not break the user.