### PR TITLE
`<FloatingHelperConten/>`, `<CircularProgress/>` -fix commonjs links to go to dist instead

### DIFF
--- a/src/components/CircularProgressBar/CircularProgressBar.tsx
+++ b/src/components/CircularProgressBar/CircularProgressBar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {
   CircularProgressBar as CoreCircularProgressBar,
   CircularProgressBarProps as CoreCircularProgressBarProps
-} from 'wix-ui-core/circular-progress-bar';
+} from 'wix-ui-core/dist/src/components/circular-progress-bar';
 import CircleLoaderCheck from 'wix-ui-icons-common/system/CircleLoaderCheck';
 import CircleLoaderCheckSmall from 'wix-ui-icons-common/system/CircleLoaderCheckSmall';
 import FormFieldError from 'wix-ui-icons-common/system/FormFieldError';

--- a/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.tsx
+++ b/src/components/FloatingHelper/FloatingHelperContent/FloatingHelperContent.tsx
@@ -11,8 +11,8 @@ import {
   ButtonSize
 } from '../../Button';
 
-import { ButtonNext } from 'wix-ui-core/button-next';
-import { button } from 'wix-ui-core/themes/backoffice';
+import { ButtonNext } from 'wix-ui-core/dist/src/components/button-next';
+import { button } from 'wix-ui-core/dist/src/themes/backoffice';
 
 import { ActionButtonTheme } from './constants';
 import { Appearance } from '../constants';


### PR DESCRIPTION
It seems that because of these imports part of our components could not be tree shaked.